### PR TITLE
Use CREATE EXTENSION for ecef_eci regression test

### DIFF
--- a/regress/core/ecef_eci.sql
+++ b/regress/core/ecef_eci.sql
@@ -1,8 +1,8 @@
 -- Tests for ECEF/ECI coordinate frame conversion and ECEF accessors
 
--- Load ECEF/ECI SQL module (functions + SRIDs)
+-- Load ECEF/ECI via extension (requires postgis extension already loaded)
 SET client_min_messages TO WARNING;
-\i :scriptdir/ecef_eci.sql
+CREATE EXTENSION IF NOT EXISTS postgis_ecef_eci;
 RESET client_min_messages;
 
 --------------------------------------------
@@ -488,3 +488,15 @@ SELECT 'accel_format',
 	postgis_accel_features() LIKE 'SIMD: %' AND
 	postgis_accel_features() LIKE '%GPU: %' AND
 	postgis_accel_features() LIKE '%Valkey: %';
+
+--------------------------------------------
+-- 9. Extension Cleanup
+--------------------------------------------
+
+-- Drop extension to verify clean removal (functions, tables, etc.)
+SET client_min_messages TO WARNING;
+DROP EXTENSION IF EXISTS postgis_ecef_eci CASCADE;
+RESET client_min_messages;
+
+-- Clean up ECI SRIDs added to spatial_ref_sys (not tracked by extension)
+DELETE FROM spatial_ref_sys WHERE srid IN (900001, 900002, 900003);


### PR DESCRIPTION
## Summary
- Replace `\i scriptdir/ecef_eci.sql` with `CREATE EXTENSION postgis_ecef_eci` in the regression test, properly testing the extension packaging path
- Add `DROP EXTENSION` and SRID cleanup at test end, fixing the object count mismatch (`spatial_ref_sys` row count pre-test != post-test)
- All 413 CUnit tests pass, regression test passes with 0 failures including object count and uninstall checks

## Test plan
- [x] `make -C liblwgeom check` — 413/413 pass
- [x] `run_test.pl --extension regress/core/ecef_eci.sql` — 0 failures (object count now matches)
- [x] Manual `CREATE EXTENSION postgis_ecef_eci` / `DROP EXTENSION` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)