### PR TITLE
Add EOP-enhanced precision for ECI coordinate transforms

### DIFF
--- a/liblwgeom/liblwgeom.h.in
+++ b/liblwgeom/liblwgeom.h.in
@@ -2667,6 +2667,22 @@ int lwgeom_transform_eci_to_ecef_m(LWGEOM *geom);
 int lwgeom_transform_ecef_to_eci_m(LWGEOM *geom);
 
 /**
+ * Transform ECEF to ECI with Earth Orientation Parameters.
+ * dut1: UT1-UTC in seconds, xp/yp: polar motion in arcseconds.
+ * Applies IERS 2003 convention: ECI = Rz(ERA_UT1) * Rx(-yp) * Ry(-xp) * ECEF
+ */
+int lwgeom_transform_ecef_to_eci_eop(LWGEOM *geom, double epoch,
+                                      double dut1, double xp, double yp);
+
+/**
+ * Transform ECI to ECEF with Earth Orientation Parameters.
+ * dut1: UT1-UTC in seconds, xp/yp: polar motion in arcseconds.
+ * Applies IERS 2003 convention: ECEF = Ry(xp) * Rx(yp) * Rz(-ERA_UT1) * ECI
+ */
+int lwgeom_transform_eci_to_ecef_eop(LWGEOM *geom, double epoch,
+                                      double dut1, double xp, double yp);
+
+/**
  * Compute bounding box for an ECI geometry.
  * Uses standard Cartesian GBOX computation (no geodetic normalization).
  * M coordinate tracks temporal (epoch) extent when present.

--- a/liblwgeom/lwgeom_eci.c
+++ b/liblwgeom/lwgeom_eci.c
@@ -280,6 +280,198 @@ lwgeom_transform_ecef_to_eci_m(LWGEOM *geom)
 }
 
 /***************************************************************************/
+/* EOP-Enhanced Transforms                                                  */
+/*                                                                          */
+/* With Earth Orientation Parameters (EOP), the simplified ERA-only         */
+/* rotation is enhanced with:                                               */
+/*   1. dut1 correction: ERA computed using UT1 instead of UTC              */
+/*   2. Polar motion (xp, yp): additional X/Y axis rotations               */
+/*                                                                          */
+/* IERS 2003 convention (simplified, no precession-nutation):               */
+/*   ECEF = Ry(xp) * Rx(yp) * Rz(-ERA_UT1) * ECI                         */
+/*   ECI  = Rz(+ERA_UT1) * Rx(-yp) * Ry(-xp) * ECEF                      */
+/*                                                                          */
+/* where xp, yp are polar motion in arcseconds and dut1 is UT1-UTC in      */
+/* seconds. The TIO locator s' is neglected (sub-microarcsecond).          */
+/***************************************************************************/
+
+/* Arcseconds to radians */
+#define ARCSEC_TO_RAD (M_PI / (180.0 * 3600.0))
+
+/**
+ * Apply X-axis rotation (Rx) to a POINTARRAY.
+ * Rx(theta): y' = y*cos - z*sin, z' = y*sin + z*cos
+ */
+static int
+ptarray_rotate_x(POINTARRAY *pa, double theta)
+{
+	uint32_t i;
+	double cos_t = cos(theta);
+	double sin_t = sin(theta);
+	POINT4D p;
+
+	for (i = 0; i < pa->npoints; i++)
+	{
+		getPoint4d_p(pa, i, &p);
+		double y = p.y, z = p.z;
+		p.y = y * cos_t - z * sin_t;
+		p.z = y * sin_t + z * cos_t;
+		ptarray_set_point4d(pa, i, &p);
+	}
+	return LW_SUCCESS;
+}
+
+/**
+ * Apply Y-axis rotation (Ry) to a POINTARRAY.
+ * Ry(theta): x' = x*cos + z*sin, z' = -x*sin + z*cos
+ */
+static int
+ptarray_rotate_y(POINTARRAY *pa, double theta)
+{
+	uint32_t i;
+	double cos_t = cos(theta);
+	double sin_t = sin(theta);
+	POINT4D p;
+
+	for (i = 0; i < pa->npoints; i++)
+	{
+		getPoint4d_p(pa, i, &p);
+		double x = p.x, z = p.z;
+		p.x = x * cos_t + z * sin_t;
+		p.z = -x * sin_t + z * cos_t;
+		ptarray_set_point4d(pa, i, &p);
+	}
+	return LW_SUCCESS;
+}
+
+/**
+ * Apply X or Y axis rotation to all points in a geometry.
+ * axis: 0 = X-axis, 1 = Y-axis
+ */
+static int
+lwgeom_rotate_xy(LWGEOM *geom, double theta, int axis)
+{
+	uint32_t i;
+	int (*rotate_fn)(POINTARRAY *, double) = axis ? ptarray_rotate_y : ptarray_rotate_x;
+
+	if (lwgeom_is_empty(geom))
+		return LW_SUCCESS;
+
+	switch (geom->type)
+	{
+	case POINTTYPE:
+	case LINETYPE:
+	case CIRCSTRINGTYPE:
+	case TRIANGLETYPE:
+	{
+		LWLINE *g = (LWLINE *)geom;
+		return rotate_fn(g->points, theta);
+	}
+	case POLYGONTYPE:
+	{
+		LWPOLY *g = (LWPOLY *)geom;
+		for (i = 0; i < g->nrings; i++)
+		{
+			if (rotate_fn(g->rings[i], theta) != LW_SUCCESS)
+				return LW_FAILURE;
+		}
+		return LW_SUCCESS;
+	}
+	case MULTIPOINTTYPE:
+	case MULTILINETYPE:
+	case MULTIPOLYGONTYPE:
+	case COLLECTIONTYPE:
+	case COMPOUNDTYPE:
+	case CURVEPOLYTYPE:
+	case MULTICURVETYPE:
+	case MULTISURFACETYPE:
+	case POLYHEDRALSURFACETYPE:
+	case TINTYPE:
+	{
+		LWCOLLECTION *g = (LWCOLLECTION *)geom;
+		for (i = 0; i < g->ngeoms; i++)
+		{
+			if (lwgeom_rotate_xy(g->geoms[i], theta, axis) != LW_SUCCESS)
+				return LW_FAILURE;
+		}
+		return LW_SUCCESS;
+	}
+	default:
+		lwerror("lwgeom_rotate_xy: Cannot handle type '%s'",
+			lwtype_name(geom->type));
+		return LW_FAILURE;
+	}
+}
+
+int
+lwgeom_transform_ecef_to_eci_eop(LWGEOM *geom, double epoch,
+                                  double dut1, double xp, double yp)
+{
+	double jd, jd_ut1, era;
+	double xp_rad, yp_rad;
+
+	if (epoch == LWPROJ_NO_EPOCH)
+	{
+		lwerror("lwgeom_transform_ecef_to_eci_eop: epoch is required");
+		return LW_FAILURE;
+	}
+
+	/* Convert decimal year to Julian Date, apply UT1-UTC correction */
+	jd = lweci_epoch_to_jd(epoch);
+	jd_ut1 = jd + (dut1 / 86400.0);
+	era = lweci_earth_rotation_angle(jd_ut1);
+
+	/* Convert polar motion from arcseconds to radians */
+	xp_rad = xp * ARCSEC_TO_RAD;
+	yp_rad = yp * ARCSEC_TO_RAD;
+
+	/* ECI = Rz(+ERA_UT1) * Rx(-yp) * Ry(-xp) * ECEF */
+	/* Apply in reverse order to geometry: */
+	/* 1. Ry(-xp) */
+	if (lwgeom_rotate_xy(geom, -xp_rad, 1) != LW_SUCCESS)
+		return LW_FAILURE;
+	/* 2. Rx(-yp) */
+	if (lwgeom_rotate_xy(geom, -yp_rad, 0) != LW_SUCCESS)
+		return LW_FAILURE;
+	/* 3. Rz(+ERA) */
+	return lwgeom_rotate_z(geom, era);
+}
+
+int
+lwgeom_transform_eci_to_ecef_eop(LWGEOM *geom, double epoch,
+                                  double dut1, double xp, double yp)
+{
+	double jd, jd_ut1, era;
+	double xp_rad, yp_rad;
+
+	if (epoch == LWPROJ_NO_EPOCH)
+	{
+		lwerror("lwgeom_transform_eci_to_ecef_eop: epoch is required");
+		return LW_FAILURE;
+	}
+
+	/* Convert decimal year to Julian Date, apply UT1-UTC correction */
+	jd = lweci_epoch_to_jd(epoch);
+	jd_ut1 = jd + (dut1 / 86400.0);
+	era = lweci_earth_rotation_angle(jd_ut1);
+
+	/* Convert polar motion from arcseconds to radians */
+	xp_rad = xp * ARCSEC_TO_RAD;
+	yp_rad = yp * ARCSEC_TO_RAD;
+
+	/* ECEF = Ry(xp) * Rx(yp) * Rz(-ERA_UT1) * ECI */
+	/* Apply in reverse order to geometry: */
+	/* 1. Rz(-ERA) */
+	if (lwgeom_rotate_z(geom, -era) != LW_SUCCESS)
+		return LW_FAILURE;
+	/* 2. Rx(yp) */
+	if (lwgeom_rotate_xy(geom, yp_rad, 0) != LW_SUCCESS)
+		return LW_FAILURE;
+	/* 3. Ry(xp) */
+	return lwgeom_rotate_xy(geom, xp_rad, 1);
+}
+
+/***************************************************************************/
 /* ECI Bounding Box Computation                                             */
 /*                                                                          */
 /* ECI coordinates are 3D Cartesian (meters from Earth center) like ECEF.  */

--- a/postgis/ecef_eci.sql.in
+++ b/postgis/ecef_eci.sql.in
@@ -71,6 +71,70 @@ CREATE OR REPLACE FUNCTION ST_ECI_To_ECEF(geom geometry, epoch timestamptz, fram
 	PARALLEL SAFE;
 
 --------------------------------------------
+-- EOP-Enhanced Frame Conversion (C level)
+--------------------------------------------
+
+-- Internal C function: ECEF to ECI with explicit EOP parameters
+CREATE OR REPLACE FUNCTION _postgis_ecef_to_eci_eop(
+	geom geometry, epoch timestamptz, frame text,
+	dut1 float8, xp float8, yp float8)
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'postgis_ecef_to_eci_eop'
+	LANGUAGE 'c' STABLE STRICT
+	PARALLEL SAFE;
+
+-- Internal C function: ECI to ECEF with explicit EOP parameters
+CREATE OR REPLACE FUNCTION _postgis_eci_to_ecef_eop(
+	geom geometry, epoch timestamptz, frame text,
+	dut1 float8, xp float8, yp float8)
+	RETURNS geometry
+	AS 'MODULE_PATHNAME', 'postgis_eci_to_ecef_eop'
+	LANGUAGE 'c' STABLE STRICT
+	PARALLEL SAFE;
+
+--------------------------------------------
+-- EOP-Enhanced Frame Conversion (SQL wrappers)
+--------------------------------------------
+
+-- Convert ECEF to ECI with automatic EOP lookup for enhanced precision.
+-- Falls back to simplified ERA-only rotation when EOP data is unavailable.
+CREATE OR REPLACE FUNCTION ST_ECEF_To_ECI_EOP(
+	geom geometry, epoch timestamptz, frame text DEFAULT 'ICRF')
+RETURNS geometry AS $$
+DECLARE
+	eop RECORD;
+BEGIN
+	SELECT * INTO eop FROM @extschema@.postgis_eop_interpolate(epoch);
+	IF eop IS NOT NULL THEN
+		RETURN @extschema@._postgis_ecef_to_eci_eop(geom, epoch, frame,
+			eop.dut1, eop.xp, eop.yp);
+	ELSE
+		RETURN @extschema@.ST_ECEF_To_ECI(geom, epoch, frame);
+	END IF;
+END;
+$$ LANGUAGE plpgsql STABLE STRICT
+PARALLEL SAFE;
+
+-- Convert ECI to ECEF with automatic EOP lookup for enhanced precision.
+-- Falls back to simplified ERA-only rotation when EOP data is unavailable.
+CREATE OR REPLACE FUNCTION ST_ECI_To_ECEF_EOP(
+	geom geometry, epoch timestamptz, frame text DEFAULT 'ICRF')
+RETURNS geometry AS $$
+DECLARE
+	eop RECORD;
+BEGIN
+	SELECT * INTO eop FROM @extschema@.postgis_eop_interpolate(epoch);
+	IF eop IS NOT NULL THEN
+		RETURN @extschema@._postgis_eci_to_ecef_eop(geom, epoch, frame,
+			eop.dut1, eop.xp, eop.yp);
+	ELSE
+		RETURN @extschema@.ST_ECI_To_ECEF(geom, epoch, frame);
+	END IF;
+END;
+$$ LANGUAGE plpgsql STABLE STRICT
+PARALLEL SAFE;
+
+--------------------------------------------
 -- ECEF Coordinate Accessors
 --------------------------------------------
 

--- a/postgis/lwgeom_ecef_eci.c
+++ b/postgis/lwgeom_ecef_eci.c
@@ -217,6 +217,130 @@ Datum postgis_eci_to_ecef(PG_FUNCTION_ARGS)
 }
 
 /* ----------------------------------------------------------------
+ * EOP-Enhanced Transforms
+ *
+ * postgis_ecef_to_eci_eop(geometry, timestamptz, text, float8, float8, float8) -> geometry
+ * postgis_eci_to_ecef_eop(geometry, timestamptz, text, float8, float8, float8) -> geometry
+ *
+ * These accept explicit EOP parameters (dut1, xp, yp) passed from SQL.
+ * ---------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1(postgis_ecef_to_eci_eop);
+Datum postgis_ecef_to_eci_eop(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *geom_in;
+	LWGEOM *lwgeom;
+	GSERIALIZED *result;
+	TimestampTz ts;
+	text *frame_text;
+	char *frame_str;
+	int32_t srid_from;
+	int32_t srid_to;
+	double epoch;
+	double dut1, xp, yp;
+
+	geom_in = PG_GETARG_GSERIALIZED_P_COPY(0);
+	ts = PG_GETARG_TIMESTAMPTZ(1);
+	frame_text = PG_GETARG_TEXT_P(2);
+	dut1 = PG_GETARG_FLOAT8(3);
+	xp = PG_GETARG_FLOAT8(4);
+	yp = PG_GETARG_FLOAT8(5);
+
+	/* Validate input SRID */
+	srid_from = gserialized_get_srid(geom_in);
+	if (srid_from != SRID_ECEF)
+		elog(ERROR, "postgis_ecef_to_eci_eop: input must have SRID %d (ECEF), got %d",
+			 SRID_ECEF, srid_from);
+
+	/* Parse target frame */
+	frame_str = text_to_cstring(frame_text);
+	srid_to = parse_eci_frame(frame_str);
+	if (srid_to == 0)
+		elog(ERROR, "postgis_ecef_to_eci_eop: unrecognized frame '%s'", frame_str);
+
+	/* Convert timestamp to decimal year */
+	epoch = timestamptz_to_decimal_year(ts);
+
+	/* Transform with EOP corrections */
+	lwgeom = lwgeom_from_gserialized(geom_in);
+	if (lwgeom_transform_ecef_to_eci_eop(lwgeom, epoch, dut1, xp, yp) != LW_SUCCESS)
+	{
+		lwgeom_free(lwgeom);
+		PG_FREE_IF_COPY(geom_in, 0);
+		elog(ERROR, "postgis_ecef_to_eci_eop: transform failed");
+	}
+
+	lwgeom->srid = srid_to;
+	if (lwgeom->bbox)
+		lwgeom_refresh_bbox(lwgeom);
+
+	result = geometry_serialize(lwgeom);
+	lwgeom_free(lwgeom);
+	PG_FREE_IF_COPY(geom_in, 0);
+
+	PG_RETURN_POINTER(result);
+}
+
+PG_FUNCTION_INFO_V1(postgis_eci_to_ecef_eop);
+Datum postgis_eci_to_ecef_eop(PG_FUNCTION_ARGS)
+{
+	GSERIALIZED *geom_in;
+	LWGEOM *lwgeom;
+	GSERIALIZED *result;
+	TimestampTz ts;
+	text *frame_text;
+	char *frame_str;
+	int32_t srid_from;
+	int32_t srid_expected;
+	double epoch;
+	double dut1, xp, yp;
+
+	geom_in = PG_GETARG_GSERIALIZED_P_COPY(0);
+	ts = PG_GETARG_TIMESTAMPTZ(1);
+	frame_text = PG_GETARG_TEXT_P(2);
+	dut1 = PG_GETARG_FLOAT8(3);
+	xp = PG_GETARG_FLOAT8(4);
+	yp = PG_GETARG_FLOAT8(5);
+
+	/* Validate input SRID */
+	srid_from = gserialized_get_srid(geom_in);
+	if (!SRID_IS_ECI(srid_from))
+		elog(ERROR, "postgis_eci_to_ecef_eop: input must have ECI SRID (%d-%d), got %d",
+			 SRID_ECI_BASE, SRID_ECI_MAX, srid_from);
+
+	/* Parse frame and cross-check */
+	frame_str = text_to_cstring(frame_text);
+	srid_expected = parse_eci_frame(frame_str);
+	if (srid_expected == 0)
+		elog(ERROR, "postgis_eci_to_ecef_eop: unrecognized frame '%s'", frame_str);
+	if (srid_from != srid_expected)
+		elog(ERROR, "postgis_eci_to_ecef_eop: SRID %d does not match frame '%s' (SRID %d)",
+			 srid_from, frame_str, srid_expected);
+
+	/* Convert timestamp to decimal year */
+	epoch = timestamptz_to_decimal_year(ts);
+
+	/* Transform with EOP corrections */
+	lwgeom = lwgeom_from_gserialized(geom_in);
+	if (lwgeom_transform_eci_to_ecef_eop(lwgeom, epoch, dut1, xp, yp) != LW_SUCCESS)
+	{
+		lwgeom_free(lwgeom);
+		PG_FREE_IF_COPY(geom_in, 0);
+		elog(ERROR, "postgis_eci_to_ecef_eop: transform failed");
+	}
+
+	lwgeom->srid = SRID_ECEF;
+	if (lwgeom->bbox)
+		lwgeom_refresh_bbox(lwgeom);
+
+	result = geometry_serialize(lwgeom);
+	lwgeom_free(lwgeom);
+	PG_FREE_IF_COPY(geom_in, 0);
+
+	PG_RETURN_POINTER(result);
+}
+
+/* ----------------------------------------------------------------
  * ECEF Coordinate Accessors
  *
  * ST_ECEF_X(geometry) -> float8

--- a/regress/core/ecef_eci.sql
+++ b/regress/core/ecef_eci.sql
@@ -190,6 +190,68 @@ SELECT 'eop_after_range',
 		('2000-01-01 00:00:00+00'::timestamptz + ((60003.0 - 51544.0) * 86400)::int * interval '1 second')
 	)) = 0;
 
+--------------------------------------------
+-- 5a. EOP-Enhanced Transform Tests
+--------------------------------------------
+
+-- EOP-enhanced round-trip: ECEF->ECI->ECEF with EOP should recover coordinates
+-- Use the sample EOP data already loaded (MJD 60000-60002)
+-- MJD 60000.5 -> epoch ~2023-02-25 (within our EOP data range)
+SELECT 'eop_roundtrip',
+	abs(ST_X(result) - 6378137) < 0.01 AND
+	abs(ST_Y(result)) < 0.01 AND
+	abs(ST_Z(result) - 4500000) < 0.01
+FROM (
+	SELECT ST_ECI_To_ECEF_EOP(
+		ST_ECEF_To_ECI_EOP(
+			ST_SetSRID(ST_MakePoint(6378137, 0, 4500000), 4978),
+			('2000-01-01 00:00:00+00'::timestamptz + ((60000.5 - 51544.0) * 86400)::int * interval '1 second'),
+			'ICRF'),
+		('2000-01-01 00:00:00+00'::timestamptz + ((60000.5 - 51544.0) * 86400)::int * interval '1 second'),
+		'ICRF') AS result
+) sub;
+
+-- EOP transform should differ from non-EOP transform
+-- dut1=0.055 sec should shift ERA by ~0.83 arcsec = ~160m at equator
+SELECT 'eop_differs',
+	abs(ST_X(eci_basic) - ST_X(eci_eop)) > 0.1 OR
+	abs(ST_Y(eci_basic) - ST_Y(eci_eop)) > 0.1
+FROM (
+	SELECT
+		ST_ECEF_To_ECI(
+			ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
+			('2000-01-01 00:00:00+00'::timestamptz + ((60000.5 - 51544.0) * 86400)::int * interval '1 second'),
+			'ICRF') AS eci_basic,
+		ST_ECEF_To_ECI_EOP(
+			ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
+			('2000-01-01 00:00:00+00'::timestamptz + ((60000.5 - 51544.0) * 86400)::int * interval '1 second'),
+			'ICRF') AS eci_eop
+) sub;
+
+-- EOP fallback: epoch outside EOP range should fall back to non-EOP transform
+-- and produce identical results
+SELECT 'eop_fallback',
+	abs(ST_X(eci_basic) - ST_X(eci_eop)) < 0.001 AND
+	abs(ST_Y(eci_basic) - ST_Y(eci_eop)) < 0.001
+FROM (
+	SELECT
+		ST_ECEF_To_ECI(
+			ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
+			'2020-01-01 00:00:00+00'::timestamptz,
+			'ICRF') AS eci_basic,
+		ST_ECEF_To_ECI_EOP(
+			ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
+			'2020-01-01 00:00:00+00'::timestamptz,
+			'ICRF') AS eci_eop
+) sub;
+
+-- Z coordinate preserved through EOP-enhanced rotation
+SELECT 'eop_z_preserved',
+	abs(ST_Z(ST_ECEF_To_ECI_EOP(
+		ST_SetSRID(ST_MakePoint(4000000, 3000000, 4500000), 4978),
+		('2000-01-01 00:00:00+00'::timestamptz + ((60000.5 - 51544.0) * 86400)::int * interval '1 second'),
+		'ICRF')) - 4500000) < 1.0;
+
 -- Clean up EOP test data
 DELETE FROM postgis_eop WHERE mjd IN (60000.0, 60001.0, 60002.0);
 

--- a/regress/core/ecef_eci_expected
+++ b/regress/core/ecef_eci_expected
@@ -33,6 +33,10 @@ null_frame|t
 eop_interp|0.000105|0.000210|0.055
 eop_before_range|t
 eop_after_range|t
+eop_roundtrip|t
+eop_differs|t
+eop_fallback|t
+eop_z_preserved|t
 xform_m_epoch|t
 xform_m_roundtrip|t
 xform_explicit_epoch|t


### PR DESCRIPTION
## Summary
- Wire Earth Orientation Parameters (dut1, polar motion xp/yp) into the ECI/ECEF transform pipeline using the IERS 2003 convention
- New SQL functions `ST_ECEF_To_ECI_EOP` / `ST_ECI_To_ECEF_EOP` auto-interpolate EOP from `postgis_eop` table, gracefully falling back to simplified ERA-only rotation when EOP data is unavailable
- New C-level functions `lwgeom_transform_ecef_to_eci_eop` / `lwgeom_transform_eci_to_ecef_eop` apply dut1 correction (UT1-UTC) and polar motion (Rx/Ry rotations)
- Impact: dut1 correction eliminates ~2.3 km/sec ERA error; polar motion adds ~2-3 meter precision

## Test plan
- [x] `make -C liblwgeom check` — 413/413 CUnit tests pass
- [x] `run_test.pl --extension regress/core/ecef_eci.sql` — 0 failures
- [x] EOP round-trip test: ECEF->ECI->ECEF with EOP recovers original coordinates
- [x] EOP-enhanced results differ from basic ERA-only results (dut1 shifts ERA)
- [x] Graceful fallback: epoch outside EOP range produces same result as non-EOP function
- [x] Z coordinate preserved through polar motion rotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)