### PR TITLE
ECEF/ECI: CI fixes, contract alignment, and EOP auto-refresh openspec

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -43,3 +43,4 @@ Koordinates
 Pease
 eci
 ecef
+ned

--- a/.openspec/postgis-ecef-eci-integration/interface-contract.md
+++ b/.openspec/postgis-ecef-eci-integration/interface-contract.md
@@ -1,0 +1,438 @@
+# Interface Contract: TimescaleDB <-> PostGIS ECEF/ECI
+
+## Purpose
+
+This file defines the formal interface between the TimescaleDB integration work
+(this repo) and the PostGIS ECEF/ECI fork (`montge/postgis`). It is the single
+source of truth for what each side needs from and provides to the other.
+
+**Both repos should contain a copy of this contract.** When the contract changes,
+update both copies and note the change in a commit message prefixed with
+`[contract]`.
+
+## Version
+
+Contract version: **0.4.0**
+Last updated: 2026-02-15
+Status: **All §8 gaps resolved — §8.3 closed with file-based EOP auto-refresh**
+
+---
+
+## 1. Type Definitions (PostGIS -> TimescaleDB)
+
+### 1.1 ECEF Point Type
+```
+Type:       geometry(PointZ, 4978)
+SRID:       4978 (EPSG — already in stock PostGIS)
+Storage:    Standard GSERIALIZED / WKB
+Axes:       X (meters, prime meridian), Y (meters, 90E), Z (meters, north pole)
+Datum:      WGS84
+```
+
+**Status**: [x] Confirmed — `SRID_ECEF=4978` in `postgis/lwgeom_ecef_eci.c:48`;
+test tables use `geometry(PointZ, 4978)`; SRID 4978 in stock `spatial_ref_sys.sql`
+
+### 1.2 ECI Point Type (ICRF — primary inertial frame)
+```
+Type:       geometry(PointZ, 900001)
+SRID:       900001 (user-defined range — matches SRID_ECI_ICRF in liblwgeom.h)
+Storage:    Standard GSERIALIZED / WKB (no frame metadata in binary)
+Axes:       X (meters, vernal equinox), Y (meters, 90 degrees), Z (meters, north pole)
+Frame:      ICRF (International Celestial Reference Frame)
+Epoch:      Separate from geometry — passed as function parameter
+```
+
+**Status**: [x] Confirmed by PostGIS fork (SRID_ECI_ICRF=900001 in liblwgeom.h.in)
+
+### 1.3 Additional ECI Frames
+```
+SRID 900002:  J2000 / EME2000 (Earth Mean Equator and Equinox of J2000.0)
+SRID 900003:  TEME (True Equator Mean Equinox — SGP4 native)
+```
+
+> **SRID Reconciliation Note (2026-02-10):** The original TimescaleDB contract
+> proposed SRID 900001=J2000. The PostGIS fork's C code defines
+> `SRID_ECI_ICRF=900001`, `SRID_ECI_J2000=900002`, `SRID_ECI_TEME=900003`.
+> PostGIS numbering is now canonical. ICRF is the IAU-recommended primary
+> inertial frame; J2000 is a near-equivalent for most practical purposes.
+
+**Status**: [x] Confirmed by PostGIS fork (SRID_ECI_J2000=900002, SRID_ECI_TEME=900003)
+
+### 1.4 SRID Registration
+PostGIS fork registers SRIDs in its install script via `INSERT INTO spatial_ref_sys`.
+These must be present before any TimescaleDB hypertable uses the types.
+
+**Status**: [x] Confirmed — `ecef_eci.sql.in:24-51` registers SRIDs 900001-900003
+with `ON CONFLICT (srid) DO NOTHING` for idempotent re-install
+
+---
+
+## 2. Conversion Functions (PostGIS -> TimescaleDB)
+
+### 2.1 ECEF to ECI
+```sql
+ST_ECEF_To_ECI(
+    geom    geometry(PointZ, 4978),   -- ECEF input
+    epoch   TIMESTAMPTZ,               -- conversion epoch (UTC)
+    frame   TEXT DEFAULT 'ICRF'        -- target: 'ICRF', 'J2000', 'TEME'
+) RETURNS geometry(PointZ, 900001)     -- ECI output (SRID matches frame)
+```
+- **Volatility**: STABLE (depends on EOP data, not on transaction state)
+- **Parallel safety**: PARALLEL SAFE
+- **Precision**: Sub-meter for LEO with current EOP; degrade spec TBD
+
+**Status**: [x] Signature confirmed | [x] Implemented | [x] Tested
+- Defined in `ecef_eci.sql.in:59-63` as `STABLE STRICT PARALLEL SAFE`
+- C impl: `lwgeom_ecef_eci.c:103-154` — validates SRID 4978 input, sets output
+  SRID dynamically (900001/900002/900003 based on frame)
+- SQL return type is unqualified `geometry` (standard PostGIS convention)
+- Regression tested in `regress/core/ecef_eci.sql`
+
+### 2.2 ECI to ECEF
+```sql
+ST_ECI_To_ECEF(
+    geom    geometry(PointZ, 900001),  -- ECI input
+    epoch   TIMESTAMPTZ,
+    frame   TEXT DEFAULT 'ICRF'
+) RETURNS geometry(PointZ, 4978)       -- ECEF output
+```
+- **Volatility**: STABLE
+- **Parallel safety**: PARALLEL SAFE
+
+**Status**: [x] Signature confirmed | [x] Implemented | [x] Tested
+- Defined in `ecef_eci.sql.in:67-71` as `STABLE STRICT PARALLEL SAFE`
+- C impl: `lwgeom_ecef_eci.c:163-217` — validates input via `SRID_IS_ECI()`,
+  cross-checks SRID/frame consistency (stricter than contract — rejects mismatches)
+- Sets output SRID to 4978
+
+### 2.3 Coordinate Accessors (for decomposed storage)
+```sql
+ST_ECEF_X(geom geometry) RETURNS FLOAT8   -- IMMUTABLE, PARALLEL SAFE
+ST_ECEF_Y(geom geometry) RETURNS FLOAT8   -- IMMUTABLE, PARALLEL SAFE
+ST_ECEF_Z(geom geometry) RETURNS FLOAT8   -- IMMUTABLE, PARALLEL SAFE
+```
+These are equivalent to `ST_X`, `ST_Y`, `ST_Z` but named explicitly for clarity.
+They must be **IMMUTABLE** (not just STABLE) for use in continuous aggregate
+definitions and index expressions.
+
+**Status**: [x] Confirmed | [x] Implemented
+- Defined in `ecef_eci.sql.in:142-160` as `IMMUTABLE STRICT PARALLEL SAFE`
+- C impl: `lwgeom_ecef_eci.c:354-409` — validates POINT type + SRID 4978
+- Uses `gserialized_peek_first_point()` for fast extraction
+
+### 2.4 Distance Functions
+```sql
+ST_3DDistance(a geometry, b geometry) RETURNS FLOAT8
+-- Already in stock PostGIS. Confirm it works with ECEF SRID 4978.
+-- Returns Euclidean distance in meters (not geodesic — correct for ECEF).
+
+ST_3DDWithin(a geometry, b geometry, distance FLOAT8) RETURNS BOOLEAN
+-- Already in stock PostGIS. Confirm 3D support with SRID 4978.
+```
+
+**Status**: [x] Confirmed working with ECEF and ECI types
+- `ST_3DDWithin` regression-tested with SRID 4978 (`ecef_eci.sql:447`)
+  and SRID 900001 (`ecef_eci.sql:503`)
+- Both use Cartesian 3D Euclidean — correct for ECEF/ECI (meters)
+- SRID mismatch enforced: cross-SRID queries correctly raise errors
+
+### 2.5 EOP-Enhanced Conversion Functions (not in original contract)
+```sql
+ST_ECEF_To_ECI_EOP(geom geometry, epoch TIMESTAMPTZ, frame TEXT DEFAULT 'ICRF')
+    RETURNS geometry  -- STABLE STRICT PARALLEL SAFE
+ST_ECI_To_ECEF_EOP(geom geometry, epoch TIMESTAMPTZ, frame TEXT DEFAULT 'ICRF')
+    RETURNS geometry  -- STABLE STRICT PARALLEL SAFE
+```
+- SQL wrappers (`ecef_eci.sql.in:101-135`) that auto-lookup EOP parameters
+  via `postgis_eop_interpolate()` and fall back to non-EOP functions when
+  no EOP data is available
+- Implements IERS 2003 convention: dut1 correction to ERA + Rx(yp)/Ry(xp)
+  polar motion rotations
+
+### 2.6 ST_Transform Epoch Overload (alternative path)
+```sql
+ST_Transform(geom geometry, to_srid INTEGER, epoch TIMESTAMPTZ)
+    RETURNS geometry  -- STABLE STRICT PARALLEL SAFE
+```
+- Provides an alternative: `ST_Transform(ecef_geom, 900001, epoch)` is
+  equivalent to `ST_ECEF_To_ECI(ecef_geom, epoch, 'ICRF')`
+- Also supports M-coordinate epoch path: 2-arg `ST_Transform(geomM, srid)`
+  uses per-point M values as decimal-year epochs
+- Volatility now consistent with `ST_ECEF_To_ECI` (both STABLE)
+
+---
+
+## 3. Operator Classes (PostGIS -> TimescaleDB)
+
+### 3.1 GiST 3D Index Support
+```sql
+CREATE INDEX ... USING gist (pos_ecef gist_geometry_ops_nd);
+```
+- Must support 3D bounding box operations on SRID 4978 and 900001+
+- Used for within-chunk spatial indexing in TimescaleDB
+
+**Status**: [x] Confirmed working with ECEF/ECI types
+- Regression tests create GiST ND indexes on both SRID 4978 (`ecef_eci.sql:403`)
+  and SRID 900001 (`ecef_eci.sql:477`)
+- Index scan verified (not seq scan) for `&&&` and `ST_3DDWithin` queries
+- No GiST C code modifications needed — operator class is SRID-agnostic
+- ECI GBOX computed via `lwgeom_eci_compute_gbox()` using Cartesian (not geodetic)
+  bounding boxes (`lwgeom_eci.c:494-510`)
+- Benchmark script at `regress/core/ecef_gist_benchmark.sql` (10K-100K points)
+
+### 3.2 Selectivity Estimators
+PostGIS selectivity estimators (`gserialized_gist_sel`, etc.) should work
+with ECEF/ECI types for accurate query planning across TimescaleDB chunks.
+
+**Status**: [x] Confirmed — estimators are SRID-agnostic, operate on N-D
+bounding box overlap ratios. No ECEF/ECI-specific code needed.
+
+### 3.3 Geocentric Guards (not in original contract)
+The PostGIS fork adds guards on 11+ spatial functions to prevent misuse
+with geocentric (ECEF) types. Functions like `ST_Area`, `ST_Buffer`,
+`ST_Centroid`, `ST_Perimeter`, `ST_Azimuth`, `ST_Project`, `ST_Segmentize`
+raise `ERRCODE_FEATURE_NOT_SUPPORTED` for SRID 4978 input.
+
+`ST_Distance`, `ST_Length`, `ST_DWithin` dispatch to 3D Euclidean
+instead of erroring.
+
+> **Resolved (§8.1)**: Guards now check both `LW_CRS_GEOCENTRIC` and
+> `LW_CRS_INERTIAL`, blocking ECI input from geodetic functions as well.
+
+---
+
+## 4. Earth Orientation Parameters (PostGIS -> TimescaleDB)
+
+### 4.1 EOP Storage
+```sql
+-- Table managed by PostGIS fork
+CREATE TABLE IF NOT EXISTS postgis_eop (
+    mjd         FLOAT8 PRIMARY KEY,    -- Modified Julian Date
+    xp          FLOAT8,                -- Polar motion X (arcseconds)
+    yp          FLOAT8,                -- Polar motion Y (arcseconds)
+    dut1        FLOAT8,                -- UT1 - UTC (seconds)
+    dx          FLOAT8,                -- Celestial pole offset X (milliarcseconds)
+    dy          FLOAT8                 -- Celestial pole offset Y (milliarcseconds)
+);
+```
+
+**Status**: [x] Schema confirmed | [x] Load mechanism defined
+- Defined in `ecef_eci.sql.in:166-173` — matches contract with additive
+  CHECK constraints: `xp/yp BETWEEN -0.000278 AND 0.000278`, `dut1 BETWEEN -1.0 AND 1.0`
+- `postgis_eop_load(data TEXT) RETURNS integer` — parses IERS Bulletin A
+  fixed-width format, upserts via `ON CONFLICT (mjd) DO UPDATE`
+- `postgis_eop_interpolate(epoch TIMESTAMPTZ) RETURNS TABLE(xp, yp, dut1, dx, dy)`
+  — converts epoch to MJD, linear interpolation between bracketing rows
+- CUnit tests in `cu_eci.c:827-957` (5 EOP-specific tests)
+- Regression tests in `ecef_eci.sql:163-256`
+
+### 4.2 EOP Refresh Job
+TimescaleDB can schedule periodic EOP updates:
+```sql
+SELECT add_job('postgis_refresh_eop', schedule_interval => INTERVAL '1 day');
+```
+PostGIS fork must provide the `postgis_refresh_eop` procedure.
+
+**Status**: [x] Procedure defined | [x] TimescaleDB-side refresh implemented
+- PostGIS: `ecef_eci.sql.in:299-304` — placeholder (emits RAISE NOTICE);
+  overload `postgis_refresh_eop(job_id INT, config JSONB)` added for `add_job()` compat
+- TimescaleDB: `ecef_eci.refresh_eop(INT, JSONB)` — production-ready file-based
+  refresh with error handling, staleness detection, and PostGIS sync
+- External download: `scripts/fetch_iers_eop.sh` (cron/systemd timer)
+- Setup convenience: `ecef_eci.setup_eop_refresh(file_path, interval, threshold)`
+
+---
+
+## 5. Extension Metadata (PostGIS -> TimescaleDB)
+
+### 5.1 Extension Identity
+```
+Extension name:     postgis_ecef_eci
+Depends on:         postgis  (no version floor — PG .control limitation)
+Min PostgreSQL:     Not enforced in extension (PG12+ via PostGIS configure.ac)
+Control file:       postgis_ecef_eci.control
+Version:            3.7.0dev
+```
+
+**Status**: [x] Packaging approach confirmed
+- Control file: `extensions/postgis_ecef_eci/postgis_ecef_eci.control.in`
+- Makefile: `extensions/postgis_ecef_eci/Makefile.in` (PGXS, follows `postgis_sfcgal` pattern)
+- Unconditionally built (no `ifeq` guard in `extensions/Makefile.in:34`)
+- Install SQL: `postgis_ecef_eci--3.7.0dev.sql`
+- Upgrade paths: `--ANY--3.7.0dev.sql`, `--unpackaged--3.7.0dev.sql`
+- C functions compiled into main `postgis-3.so` (not a separate `.so`)
+
+### 5.2 Planner/Executor Hooks
+List any hooks the PostGIS fork registers (beyond stock PostGIS):
+```
+Hook name:          NONE
+Chaining:           N/A
+```
+
+**Status**: [x] Confirmed — zero planner/executor/parse-analysis hooks
+in entire fork. All `_PG_init` functions audited. Fork adds two GUCs
+(Valkey batch workers, GPU dispatch threshold) but no hooks.
+
+---
+
+## 6. What TimescaleDB Provides to PostGIS
+
+### 6.1 Chunk Constraint Format
+TimescaleDB CHECK constraints on chunk tables:
+```sql
+-- Time dimension
+CHECK (time >= '2025-01-01 00:00:00+00' AND time < '2025-01-01 01:00:00+00')
+
+-- Closed dimension (spatial bucket)
+CHECK (spatial_bucket >= 0 AND spatial_bucket < 4)
+```
+PostGIS planner hooks should not interfere with these constraints.
+
+### 6.2 Compression Behavior
+- Geometry columns compressed with Array algorithm (TOAST/LZ fallback)
+- Compressed chunks have no GiST indexes
+- Decompression is segment-at-a-time, not row-at-a-time
+- `SEGMENT BY object_id, ORDER BY time ASC`
+
+### 6.3 Continuous Aggregate Constraints
+Functions used in continuous aggregate definitions must be:
+- **IMMUTABLE** (preferred) or **STABLE** for the defining query
+- **PARALLEL SAFE** for optimal execution
+- Must not reference mutable state (no VOLATILE functions)
+
+Frame conversion functions (STABLE, depends on EOP) can be used in
+regular queries but **NOT** in continuous aggregate definitions.
+
+### 6.4 Background Job Scheduling
+```sql
+-- TimescaleDB provides:
+SELECT add_job(proc REGPROC, schedule_interval INTERVAL, ...) RETURNS INTEGER;
+SELECT delete_job(job_id INTEGER);
+SELECT alter_job(job_id INTEGER, schedule_interval INTERVAL, ...);
+```
+Available for PostGIS fork to schedule EOP refresh, SRID maintenance, etc.
+
+---
+
+## 7. Integration Test Checklist
+
+Both sides must pass these tests:
+
+- [ ] `CREATE EXTENSION postgis; CREATE EXTENSION postgis_ecef_eci; CREATE EXTENSION timescaledb;` — succeeds
+- [ ] Reverse order: `CREATE EXTENSION timescaledb; CREATE EXTENSION postgis; CREATE EXTENSION postgis_ecef_eci;` — succeeds
+- [ ] `CREATE TABLE ... (pos geometry(PointZ, 4978)); SELECT create_hypertable(...)` — succeeds
+- [ ] INSERT ECEF point, SELECT back — data integrity
+- [ ] `ST_3DDistance` query with GiST index on hypertable — correct results
+- [ ] Compress chunk with geometry column — succeeds
+- [ ] SELECT from compressed chunk — geometry data intact
+- [ ] `ST_ECEF_To_ECI(pos, time)` on hypertable — correct conversion
+- [ ] Continuous aggregate with `avg(x), avg(y), avg(z)` — refreshes correctly
+- [ ] `ALTER EXTENSION postgis_ecef_eci UPDATE` — no data loss
+- [ ] `ALTER EXTENSION timescaledb UPDATE` — no data loss
+- [ ] Both extensions in same `pg_dump` / `pg_restore` cycle — succeeds
+
+---
+
+## 8. Remaining Gaps & Open Questions
+
+These items surfaced during the 2026-02-15 audit and need decisions before
+the integration can proceed to live testing.
+
+### 8.1 ECI Geocentric Guards Gap
+**Problem**: Spatial function guards (§3.3) block `LW_CRS_GEOCENTRIC` (SRID 4978)
+from functions like `ST_Area`, `ST_Buffer`, `ST_Centroid`. But they do NOT block
+`LW_CRS_INERTIAL` (SRID 900001+). These functions would produce equally
+meaningless results on ECI input — `ST_Area` of an ECI polygon has no physical
+meaning.
+
+**Options**:
+- (a) Broaden guards to `_not_geocentric_or_inertial` — safest
+- (b) Leave as-is, document that ECI users must avoid geodetic functions — least work
+- (c) Add ECI-specific guards only for the most dangerous functions
+
+**Decision**: [x] Option (a) — `srid_check_crs_family_not_geocentric()` broadened
+to check both `LW_CRS_GEOCENTRIC` and `LW_CRS_INERTIAL`. All 12 call sites
+automatically get ECI blocking. No function-level changes needed.
+
+### 8.2 EOP Refresh Procedure Signature
+**Problem**: `postgis_refresh_eop()` takes zero arguments. TimescaleDB's `add_job()`
+passes `(job_id INT, config JSONB)` to scheduled procedures.
+
+**Options**:
+- (a) PostGIS adds overload: `postgis_refresh_eop(job_id INT, config JSONB)`
+- (b) TimescaleDB wraps it: `CREATE PROCEDURE _ts_eop_refresh(INT, JSONB) AS $$ CALL postgis_refresh_eop(); $$`
+- (c) Both — PostGIS adds the overload, TimescaleDB uses it directly
+
+**Decision**: [x] Option (a) — PostGIS added overload
+`postgis_refresh_eop(job_id INT, config JSONB)`. Compatible with
+TimescaleDB `add_job()` signature directly.
+
+### 8.3 EOP Automatic Fetching
+**Problem**: `postgis_refresh_eop()` is a placeholder (RAISE NOTICE only). It does
+not actually fetch IERS Bulletin A data. Users must manually obtain the data and
+call `postgis_eop_load(text)`.
+
+**Options**:
+- (a) PostGIS implements HTTP fetch via `pg_curl` or `http` extension dependency
+- (b) PostGIS provides a shell script, TimescaleDB job calls it via `pg_cron`
+- (c) Leave as manual process, document the workflow
+- (d) TimescaleDB side implements the fetch in its own wrapper job
+
+**Decision**: [x] Option (d) — File-based refresh architecture. External scheduler
+(cron/systemd) downloads IERS Bulletin A via `scripts/fetch_iers_eop.sh`. TimescaleDB
+background job (`ecef_eci.refresh_eop`) reads the local file via `pg_read_file()`,
+loads into `ecef_eci.eop_data`, and syncs to PostGIS's `postgis_eop` table via
+`ecef_eci.sync_eop_to_postgis()`. No HTTP extension dependency required.
+
+Functions added:
+- `ecef_eci.sync_eop_to_postgis() RETURNS INT` — upserts eop_data into postgis_eop
+- `ecef_eci.eop_staleness(threshold_days INT) RETURNS TABLE` — gap_days, is_stale, load_age_hours
+- `ecef_eci.setup_eop_refresh(file_path, interval, threshold) RETURNS INT` — convenience wrapper
+
+**Note**: PostGIS's `postgis_eop_load()` parser has incorrect column offsets for
+MJD, PM-x, and PM-y fields. Data flows exclusively through the TimescaleDB parser
+(`load_eop_finals2000a`), avoiding this bug. The PostGIS parser should be fixed
+separately.
+
+### 8.4 ST_Transform Epoch Volatility Inconsistency
+**Problem**: `ST_Transform(geom, srid, epoch)` is declared `IMMUTABLE` but
+`ST_ECEF_To_ECI(geom, epoch, frame)` is `STABLE`. Both call the same underlying
+`lwgeom_transform_ecef_to_eci()`. For the non-EOP ERA-only path, IMMUTABLE is
+technically correct (pure math). But this inconsistency could cause confusion
+for continuous aggregate usage.
+
+**Impact**: If users discover that `ST_Transform` epoch overload works in cagg
+definitions (because IMMUTABLE) while `ST_ECEF_To_ECI` doesn't (because STABLE),
+they may use the wrong function to bypass the safety check.
+
+**Options**:
+- (a) Downgrade `ST_Transform` epoch overload to STABLE — consistent but limits cagg use
+- (b) Upgrade `ST_ECEF_To_ECI` to IMMUTABLE for the non-EOP path — risky if EOP is added later
+- (c) Document the difference and accept it
+
+**Decision**: [x] Option (a) — `ST_Transform(geom, srid, epoch)` downgraded
+from IMMUTABLE to STABLE. Consistent with `ST_ECEF_To_ECI` volatility.
+Neither function can be used in continuous aggregate definitions; users
+should use decomposed float columns for caggs instead.
+
+### 8.5 Precession-Nutation Model
+**Current state**: PostGIS implements IERS 2003 simplified model for ECI transforms.
+Full IERS 2006/2000A precession-nutation is documented as deferred.
+
+**Impact on TimescaleDB**: For LEO conjunction screening at sub-kilometer accuracy,
+the simplified model is sufficient. For high-precision GEO operations, the full
+model may be needed.
+
+**Decision**: [x] Acceptable for Phase 1 — revisit if precision requirements tighten
+
+---
+
+## Change Log
+
+| Date | Version | Change | Author |
+|------|---------|--------|--------|
+| 2025-01-01 | 0.1.0-draft | Initial contract | TimescaleDB integration (claude branch) |
+| 2026-02-10 | 0.2.0-draft | Align SRID numbering with PostGIS fork: ICRF=900001, J2000=900002, TEME=900003; default frame 'ICRF' | PostGIS openspec creation |
+| 2026-02-15 | 0.3.0 | Audit PostGIS `develop` branch: confirm all §1-5 deliverables; add §2.5 EOP-enhanced functions, §2.6 ST_Transform epoch overload, §3.3 geocentric guards; document 5 open gaps in §8 | Audit against commit 00bc1009d |
+| 2026-02-15 | 0.3.1 | Resolve §8.1 (ECI guards broadened), §8.2 (EOP refresh overload added), §8.4 (ST_Transform epoch downgraded to STABLE), §8.5 (precession-nutation accepted for Phase 1); update §2.6 volatility to STABLE; §8.3 remains open | Contract alignment fixes |
+| 2026-02-15 | 0.4.0 | Resolve §8.3: file-based EOP auto-refresh — add sync_eop_to_postgis(), eop_staleness(), setup_eop_refresh(); external download script; all §8 gaps now closed | EOP auto-refresh implementation |

--- a/liblwgeom/lwgeom_transform.c
+++ b/liblwgeom/lwgeom_transform.c
@@ -110,6 +110,10 @@ lwsrid_get_crs_family(int32_t srid)
 	PJ *pj_crs;
 	LW_CRS_FAMILY family;
 
+	/* SRID 0 (unknown/unset) is not in EPSG registry */
+	if (srid == SRID_UNKNOWN)
+		return LW_CRS_UNKNOWN;
+
 	/* Check for custom ECI SRID range (not in EPSG registry) */
 	if (SRID_IS_ECI(srid))
 		return LW_CRS_INERTIAL;

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -560,6 +560,10 @@ srid_get_crs_family(int32_t srid)
 {
 	LWPROJ *pj;
 
+	/* SRID 0 (unknown/unset) is not in spatial_ref_sys */
+	if (srid == SRID_UNKNOWN)
+		return LW_CRS_UNKNOWN;
+
 	/* Check for custom ECI SRID range (not in EPSG registry) */
 	if (SRID_IS_ECI(srid))
 		return LW_CRS_INERTIAL;
@@ -599,6 +603,14 @@ srid_check_crs_family_not_geocentric(int32_t srid, const char *funcname)
 		ereport(ERROR, (
 			errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			errmsg("%s: Operation is not supported for geocentric (ECEF) coordinates (SRID=%d). "
+				"Transform to a geographic or projected CRS first.",
+				funcname, srid)));
+	}
+	if (family == LW_CRS_INERTIAL)
+	{
+		ereport(ERROR, (
+			errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			errmsg("%s: Operation is not supported for inertial (ECI) coordinates (SRID=%d). "
 				"Transform to a geographic or projected CRS first.",
 				funcname, srid)));
 	}

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -18,6 +18,7 @@
 #include "utils/memutils.h"
 #include "executor/spi.h"
 #include "access/hash.h"
+#include "access/xact.h"
 #include "utils/hsearch.h"
 
 /* PostGIS headers */
@@ -558,13 +559,39 @@ srid_axis_precision(int32_t srid, int precision)
 LW_CRS_FAMILY
 srid_get_crs_family(int32_t srid)
 {
+	LWPROJ *pj;
+	LW_CRS_FAMILY family = LW_CRS_UNKNOWN;
+
+	/* SRID 0 (unknown/unset) is not in spatial_ref_sys */
+	if (srid == SRID_UNKNOWN)
+		return LW_CRS_UNKNOWN;
+
+	/* Check for custom ECI SRID range (not in EPSG registry) */
+	if (SRID_IS_ECI(srid))
+		return LW_CRS_INERTIAL;
+
 	/*
-	 * Delegate to lwsrid_get_crs_family() which uses proj_create()
-	 * directly instead of SPI-based spatial_ref_sys lookup.
-	 * This avoids elog(ERROR) for SRIDs not in spatial_ref_sys
-	 * (e.g., test SRIDs 2, 3, 42 or SRID 0).
+	 * Use a subtransaction to catch errors from lwproj_lookup().
+	 * Some SRIDs (e.g., test SRIDs 2, 3, 42) may not exist in
+	 * spatial_ref_sys, and GetProjStringsSPI throws elog(ERROR)
+	 * for unknown SRIDs.  We catch the error gracefully and
+	 * return LW_CRS_UNKNOWN instead of aborting the transaction.
 	 */
-	return lwsrid_get_crs_family(srid);
+	BeginInternalSubTransaction(NULL);
+	PG_TRY();
+	{
+		if (lwproj_lookup(srid, srid, &pj) == LW_SUCCESS)
+			family = pj->source_crs_family;
+		ReleaseCurrentSubTransaction();
+	}
+	PG_CATCH();
+	{
+		RollbackAndReleaseCurrentSubTransaction();
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	return family;
 }
 
 int

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -18,7 +18,6 @@
 #include "utils/memutils.h"
 #include "executor/spi.h"
 #include "access/hash.h"
-#include "access/xact.h"
 #include "utils/hsearch.h"
 
 /* PostGIS headers */
@@ -556,11 +555,35 @@ srid_axis_precision(int32_t srid, int precision)
 	return sp;
 }
 
+/*
+ * Check if an SRID exists in spatial_ref_sys without throwing errors.
+ * Returns true if found, false otherwise.
+ */
+static bool
+srid_exists(int32_t srid)
+{
+	int spi_result;
+	char buf[256];
+	bool found;
+
+	spi_result = SPI_connect();
+	if (spi_result != SPI_OK_CONNECT)
+		return false;
+
+	snprintf(buf, sizeof(buf),
+		"SELECT 1 FROM %s WHERE srid = %d LIMIT 1",
+		postgis_spatial_ref_sys(), srid);
+	spi_result = SPI_execute(buf, true, 1);
+	found = (spi_result == SPI_OK_SELECT && SPI_processed > 0);
+
+	SPI_finish();
+	return found;
+}
+
 LW_CRS_FAMILY
 srid_get_crs_family(int32_t srid)
 {
 	LWPROJ *pj;
-	volatile LW_CRS_FAMILY family = LW_CRS_UNKNOWN;
 
 	/* SRID 0 (unknown/unset) is not in spatial_ref_sys */
 	if (srid == SRID_UNKNOWN)
@@ -571,27 +594,29 @@ srid_get_crs_family(int32_t srid)
 		return LW_CRS_INERTIAL;
 
 	/*
-	 * Use a subtransaction to catch errors from lwproj_lookup().
-	 * Some SRIDs (e.g., test SRIDs 2, 3, 42) may not exist in
-	 * spatial_ref_sys, and GetProjStringsSPI throws elog(ERROR)
-	 * for unknown SRIDs.  We catch the error gracefully and
-	 * return LW_CRS_UNKNOWN instead of aborting the transaction.
+	 * For regular SRIDs (< SRID_RESERVE_OFFSET), check existence
+	 * in spatial_ref_sys first to avoid elog(ERROR) from
+	 * GetProjStringsSPI for unknown SRIDs.
 	 */
-	BeginInternalSubTransaction(NULL);
-	PG_TRY();
+	if (srid < SRID_RESERVE_OFFSET)
 	{
-		if (lwproj_lookup(srid, srid, &pj) == LW_SUCCESS)
-			family = pj->source_crs_family;
-		ReleaseCurrentSubTransaction();
+		if (!srid_exists(srid))
+			return LW_CRS_UNKNOWN;
 	}
-	PG_CATCH();
+	else
 	{
-		RollbackAndReleaseCurrentSubTransaction();
-		FlushErrorState();
+		/*
+		 * Reserved SRIDs: only known automagic ranges are valid.
+		 * Unknown reserved SRIDs (e.g., 999999) would cause
+		 * elog(ERROR) in GetProjStrings, so return unknown.
+		 */
+		if (srid > SRID_LAEA_END)
+			return LW_CRS_UNKNOWN;
 	}
-	PG_END_TRY();
 
-	return family;
+	if (lwproj_lookup(srid, srid, &pj) == LW_FAILURE)
+		return LW_CRS_UNKNOWN;
+	return pj->source_crs_family;
 }
 
 int

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -560,7 +560,7 @@ LW_CRS_FAMILY
 srid_get_crs_family(int32_t srid)
 {
 	LWPROJ *pj;
-	LW_CRS_FAMILY family = LW_CRS_UNKNOWN;
+	volatile LW_CRS_FAMILY family = LW_CRS_UNKNOWN;
 
 	/* SRID 0 (unknown/unset) is not in spatial_ref_sys */
 	if (srid == SRID_UNKNOWN)

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -565,6 +565,12 @@ srid_exists(int32_t srid)
 	int spi_result;
 	char buf[256];
 	bool found;
+	const char *srs_table;
+
+	/* postgis_spatial_ref_sys() returns NULL if cache is not yet initialized */
+	srs_table = postgis_spatial_ref_sys();
+	if (!srs_table)
+		srs_table = "spatial_ref_sys";
 
 	spi_result = SPI_connect();
 	if (spi_result != SPI_OK_CONNECT)
@@ -572,7 +578,7 @@ srid_exists(int32_t srid)
 
 	snprintf(buf, sizeof(buf),
 		"SELECT 1 FROM %s WHERE srid = %d LIMIT 1",
-		postgis_spatial_ref_sys(), srid);
+		srs_table, srid);
 	spi_result = SPI_execute(buf, true, 1);
 	found = (spi_result == SPI_OK_SELECT && SPI_processed > 0);
 

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -558,19 +558,13 @@ srid_axis_precision(int32_t srid, int precision)
 LW_CRS_FAMILY
 srid_get_crs_family(int32_t srid)
 {
-	LWPROJ *pj;
-
-	/* SRID 0 (unknown/unset) is not in spatial_ref_sys */
-	if (srid == SRID_UNKNOWN)
-		return LW_CRS_UNKNOWN;
-
-	/* Check for custom ECI SRID range (not in EPSG registry) */
-	if (SRID_IS_ECI(srid))
-		return LW_CRS_INERTIAL;
-
-	if (lwproj_lookup(srid, srid, &pj) == LW_FAILURE)
-		return LW_CRS_UNKNOWN;
-	return pj->source_crs_family;
+	/*
+	 * Delegate to lwsrid_get_crs_family() which uses proj_create()
+	 * directly instead of SPI-based spatial_ref_sys lookup.
+	 * This avoids elog(ERROR) for SRIDs not in spatial_ref_sys
+	 * (e.g., test SRIDs 2, 3, 42 or SRID 0).
+	 */
+	return lwsrid_get_crs_family(srid);
 }
 
 int

--- a/openspec/changes/2026-02-15-contract-alignment-fixes/.openspec.yaml
+++ b/openspec/changes/2026-02-15-contract-alignment-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/2026-02-15-contract-alignment-fixes/design.md
+++ b/openspec/changes/2026-02-15-contract-alignment-fixes/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The TimescaleDB interface contract v0.3.0 was produced by auditing the PostGIS
+`develop` branch against the integration requirements. Three gaps were identified
+in sections 8.1, 8.2, and 8.4 of the contract. All three are small, isolated
+fixes that resolve inconsistencies rather than adding new features.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close contract gap 8.1: ECI input rejected by all geocentric-guarded functions
+- Close contract gap 8.2: `postgis_refresh_eop` callable by TimescaleDB `add_job()`
+- Close contract gap 8.4: `ST_Transform` epoch overload has consistent volatility
+
+**Non-Goals:**
+- Implementing actual EOP auto-fetch (contract gap 8.3 — remains open/deferred)
+- Adding ECI-specific dispatch paths for any spatial functions
+- Modifying the guard infrastructure beyond the `LW_CRS_INERTIAL` check
+- Changing `ST_ECEF_To_ECI` volatility (it is correctly STABLE)
+
+## Decisions
+
+### 1. ECI guards: extend existing check function, not per-site guards
+
+**Decision:** Add an `LW_CRS_INERTIAL` check to `srid_check_crs_family_not_geocentric()`
+in `libpgcommon/lwgeom_transform.c`, immediately after the existing `LW_CRS_GEOCENTRIC`
+check.
+
+**Rationale:** The guard function is the single choke point for all 12 call sites.
+Modifying it once covers ST_Area, ST_Buffer, ST_Centroid, ST_OffsetCurve, ST_BuildArea,
+ST_Perimeter, ST_Azimuth, ST_Project (both variants), ST_Segmentize, and the
+geometry-to-geography cast — without touching any of those functions' C code. The
+error message is ECI-specific: "Operation is not supported for inertial (ECI)
+coordinates (SRID=N)."
+
+**Alternative considered:** Renaming the function to `_not_geocentric_or_inertial` —
+rejected because the function name is already used at 12+ call sites and the semantic
+intent ("not geocentric" in the broad sense) is clear enough. The function's behavior
+now covers all non-terrestrial CRS families.
+
+### 2. EOP refresh: overload, not rename
+
+**Decision:** Add a `postgis_refresh_eop(job_id INT, config JSONB)` overload in
+`postgis/ecef_eci.sql.in` that calls the zero-arg version. Keep the zero-arg version
+for direct `CALL` usage.
+
+**Rationale:** TimescaleDB's `add_job()` resolves the procedure by name and expects
+`(INT, JSONB)` arguments. Adding an overload is the simplest fix — one-liner
+delegation. The `job_id` and `config` parameters are accepted but unused because the
+current implementation is a placeholder. When real EOP fetching is implemented, the
+`config` parameter can carry the IERS URL and other options.
+
+**Alternative considered:** TimescaleDB-side wrapper — rejected because it adds a
+dependency direction (TimescaleDB must know about PostGIS internals) and the fix is
+trivial on the PostGIS side.
+
+### 3. ST_Transform epoch: downgrade to STABLE
+
+**Decision:** Change `ST_Transform(geom, to_srid, epoch)` from `IMMUTABLE` to
+`STABLE` in `postgis/postgis.sql.in`.
+
+**Rationale:** The epoch overload calls the same underlying C function
+(`transform_epoch` / `lwgeom_transform_ecef_to_eci`) as `ST_ECEF_To_ECI`, which is
+declared `STABLE`. While the non-EOP ERA-only path is technically pure math
+(deterministic for the same inputs), declaring it `IMMUTABLE` creates an exploitable
+inconsistency: users could use `ST_Transform` in continuous aggregate definitions to
+bypass the `STABLE` restriction on `ST_ECEF_To_ECI`. Making both `STABLE` is
+conservative and consistent. If the non-EOP path is later separated into its own C
+function, it can be made `IMMUTABLE` independently.
+
+**Impact on continuous aggregates:** Users cannot use the epoch overload in cagg
+definitions. This matches the behavior of `ST_ECEF_To_ECI` and is correct — frame
+conversions depend on time and should not be materialized in caggs without explicit
+epoch handling.

--- a/openspec/changes/2026-02-15-contract-alignment-fixes/proposal.md
+++ b/openspec/changes/2026-02-15-contract-alignment-fixes/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The TimescaleDB interface contract v0.3.0 audit (2026-02-15) identified three gaps
+between the PostGIS fork's implementation and what the TimescaleDB integration layer
+expects. These gaps block live integration testing:
+
+1. Spatial function guards blocked geocentric (ECEF, SRID 4978) input but silently
+   accepted inertial (ECI, SRID 900001+) input. Functions like `ST_Area` and
+   `ST_Buffer` produce equally meaningless results on ECI coordinates.
+
+2. `postgis_refresh_eop()` had a zero-argument signature, but TimescaleDB's
+   `add_job()` passes `(job_id INT, config JSONB)` to scheduled procedures.
+   Without a matching overload, scheduling fails at runtime.
+
+3. `ST_Transform(geom, to_srid, epoch)` was declared `IMMUTABLE` while the
+   functionally equivalent `ST_ECEF_To_ECI` was `STABLE`. The inconsistency
+   could lead users to bypass safety checks by using `ST_Transform` in continuous
+   aggregate definitions where `ST_ECEF_To_ECI` is correctly disallowed.
+
+## What Changes
+
+- Extend `srid_check_crs_family_not_geocentric()` in `libpgcommon/lwgeom_transform.c`
+  to also check for `LW_CRS_INERTIAL` and raise `ERRCODE_FEATURE_NOT_SUPPORTED`.
+  All 12 existing call sites (ST_Area, ST_Buffer, ST_Centroid, ST_OffsetCurve,
+  ST_BuildArea, ST_Perimeter, ST_Azimuth, ST_Project x2, ST_Segmentize,
+  geometry::geography) now block ECI input without any per-site changes.
+
+- Add `postgis_refresh_eop(job_id INT, config JSONB)` overload in
+  `postgis/ecef_eci.sql.in` that delegates to the zero-arg version.
+
+- Change `ST_Transform(geom, to_srid, epoch)` in `postgis/postgis.sql.in` from
+  `IMMUTABLE` to `STABLE`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `ecef-coordinate-support`: Extend guard behavior from `LW_CRS_GEOCENTRIC` only
+  to also cover `LW_CRS_INERTIAL`, making all Error-class functions reject ECI
+  input (SRID 900001-900003) with a specific error message.
+
+- `earth-orientation-parameters`: Add TimescaleDB-compatible procedure overload
+  for `postgis_refresh_eop` so that `add_job()` works without a wrapper.
+
+## Impact
+
+- **C code**: `libpgcommon/lwgeom_transform.c` — added `LW_CRS_INERTIAL` check
+  to `srid_check_crs_family_not_geocentric()` (single function, all 12 call sites
+  inherit the fix)
+- **SQL**: `postgis/ecef_eci.sql.in` — new 2-arg overload of `postgis_refresh_eop`;
+  `postgis/postgis.sql.in` — `IMMUTABLE` to `STABLE` for `ST_Transform` epoch overload
+- **Tests**: 5 new regression tests in `regress/core/ecef_eci.sql` covering ECI
+  guards for ST_Perimeter, ST_Azimuth, ST_Project, ST_Segmentize, and geography cast
+- **Existing behavior**: ECI geometries that were silently accepted by Error-class
+  spatial functions now raise errors. This is intentionally breaking for misuse cases.
+- **No new C functions**: All changes reuse existing infrastructure

--- a/openspec/changes/2026-02-15-contract-alignment-fixes/specs/README.md
+++ b/openspec/changes/2026-02-15-contract-alignment-fixes/specs/README.md
@@ -1,0 +1,17 @@
+## Affected Specs
+
+This change set modifies behavior defined in the following specs:
+
+- **ecef-coordinate-support** (`openspec/specs/ecef-coordinate-support/spec.md`)
+  - Extended: Guard behavior now covers `LW_CRS_INERTIAL` in addition to
+    `LW_CRS_GEOCENTRIC`. All Error-class functions reject ECI input (SRID 900001+).
+  - The spec's "Spatial functions error on unsupported ECEF operations" requirement
+    is broadened to cover ECI coordinates via the shared guard function.
+
+- **earth-orientation-parameters** (`openspec/specs/earth-orientation-parameters/spec.md`)
+  - Extended: `postgis_refresh_eop` now has a `(job_id INT, config JSONB)` overload
+    compatible with TimescaleDB's `add_job()` scheduler.
+  - The spec's "Compatible with TimescaleDB job scheduler" scenario is now satisfied.
+
+No new specs are introduced. The changes are strictly alignment fixes to close gaps
+identified during the TimescaleDB interface contract v0.3.0 audit.

--- a/openspec/changes/2026-02-15-contract-alignment-fixes/tasks.md
+++ b/openspec/changes/2026-02-15-contract-alignment-fixes/tasks.md
@@ -1,0 +1,35 @@
+## 1. ECI Guard Fix
+
+- [x] 1.1 Add `LW_CRS_INERTIAL` check to `srid_check_crs_family_not_geocentric()` in `libpgcommon/lwgeom_transform.c`, after the existing `LW_CRS_GEOCENTRIC` check
+- [x] 1.2 Verify ECI-specific error message: "Operation is not supported for inertial (ECI) coordinates (SRID=N). Transform to a geographic or projected CRS first."
+- [x] 1.3 Confirm all 12 existing call sites inherit the fix without per-site changes: ST_Area, ST_Buffer, ST_Centroid, ST_OffsetCurve, ST_BuildArea, ST_Perimeter, ST_Azimuth, ST_Project (direction), ST_Project (geometry), ST_Segmentize, geometry::geography, gserialized wrapper
+
+## 2. EOP Signature Fix
+
+- [x] 2.1 Add `CREATE OR REPLACE PROCEDURE postgis_refresh_eop(job_id INT, config JSONB)` overload in `postgis/ecef_eci.sql.in`
+- [x] 2.2 Overload delegates to zero-arg version via `CALL @extschema@.postgis_refresh_eop()`
+- [x] 2.3 Verify zero-arg `postgis_refresh_eop()` remains available for direct CALL usage
+
+## 3. ST_Transform Volatility Fix
+
+- [x] 3.1 Change `ST_Transform(geom geometry, to_srid integer, epoch timestamptz)` in `postgis/postgis.sql.in` from `IMMUTABLE` to `STABLE`
+- [x] 3.2 Verify `ST_ECEF_To_ECI` remains `STABLE` (no change needed — already correct)
+
+## 4. Regression Tests
+
+- [x] 4.1 Add ECI guard test: `ST_Perimeter` on SRID 900001 polygon raises error containing "inertial"
+- [x] 4.2 Add ECI guard test: `ST_Azimuth` on SRID 900001 points raises error containing "inertial"
+- [x] 4.3 Add ECI guard test: `ST_Project` (direction variant) on SRID 900001 point raises error containing "inertial"
+- [x] 4.4 Add ECI guard test: `ST_Segmentize` on SRID 900001 linestring raises error containing "inertial"
+- [x] 4.5 Add ECI guard test: geography cast on SRID 900001 geometry raises error containing "inertial"
+
+## 5. Extension SQL Update
+
+- [x] 5.1 Verify `postgis_refresh_eop(INT, JSONB)` overload included in generated extension install SQL (`postgis_ecef_eci--3.7.0dev.sql`)
+- [x] 5.2 Verify `ST_Transform` epoch volatility change reflected in `postgis.sql.in` (core extension, not ecef_eci)
+
+## 6. Contract Alignment
+
+- [x] 6.1 Update TimescaleDB interface contract §8.1 — mark ECI guards as resolved
+- [x] 6.2 Update TimescaleDB interface contract §8.2 — mark EOP signature as resolved
+- [x] 6.3 Update TimescaleDB interface contract §8.4 — mark ST_Transform volatility as resolved

--- a/openspec/changes/2026-02-15-eop-auto-refresh/design.md
+++ b/openspec/changes/2026-02-15-eop-auto-refresh/design.md
@@ -1,0 +1,62 @@
+## EOP Auto-Refresh Architecture
+
+### Data Flow
+
+```
+┌─────────────────────┐
+│  External Scheduler  │  cron / systemd timer
+│  (fetch_iers_eop.sh) │  runs daily
+└──────────┬──────────┘
+           │ curl + atomic mv
+           ▼
+┌─────────────────────┐
+│  Local File          │  /var/lib/postgresql/eop/finals2000A.all
+│  (finals2000A.all)   │
+└──────────┬──────────┘
+           │ pg_read_file()
+           ▼
+┌─────────────────────┐
+│  TimescaleDB Job     │  ecef_eci.refresh_eop(job_id, config)
+│  Background Worker   │  scheduled via add_job()
+└──────────┬──────────┘
+           │ load_eop_finals2000a()
+           ▼
+┌─────────────────────┐
+│  ecef_eci.eop_data   │  TimescaleDB-managed EOP table
+│  (TimescaleDB)       │  ~20 years of daily data
+└──────────┬──────────┘
+           │ sync_eop_to_postgis()
+           ▼
+┌─────────────────────┐
+│  postgis_eop         │  PostGIS-managed EOP table
+│  (PostGIS)           │  used by ST_ECEF_To_ECI_EOP()
+└─────────────────────┘
+```
+
+### Parser Column Offset Bug
+
+The PostGIS `postgis_eop_load()` function uses incorrect SUBSTRING offsets:
+
+| Field   | IERS Spec   | TimescaleDB Parser | PostGIS Parser (BUG) |
+|---------|-------------|-------------------|---------------------|
+| MJD     | cols 8-15   | `FROM 8 FOR 8`   | `FROM 19 FOR 9`     |
+| PM-x    | cols 19-27  | `FROM 19 FOR 9`  | `FROM 35 FOR 9`     |
+| PM-y    | cols 38-46  | `FROM 38 FOR 9`  | `FROM 44 FOR 9`     |
+| UT1-UTC | cols 59-68  | `FROM 59 FOR 10` | `FROM 59 FOR 10` (OK) |
+
+The auto-refresh pipeline avoids this by using the TimescaleDB parser exclusively.
+The PostGIS parser should be fixed separately as a standalone bug fix.
+
+### Error Handling Strategy
+
+The `refresh_eop` procedure uses `RAISE WARNING` (not `RAISE EXCEPTION`) for all
+error conditions. This ensures the TimescaleDB background job scheduler does not
+disable the job after transient failures (e.g., file not yet downloaded).
+
+Error conditions handled:
+- Missing `eop_file_path` config key
+- File not found (download not yet run)
+- Permission denied (wrong file permissions)
+- File too small (corrupt/truncated download)
+- Zero rows parsed (format mismatch)
+- Post-load staleness (download script may have stopped)

--- a/openspec/changes/2026-02-15-eop-auto-refresh/proposal.md
+++ b/openspec/changes/2026-02-15-eop-auto-refresh/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The TimescaleDB interface contract §8.3 identified that `postgis_refresh_eop()` is a
+placeholder — it emits a RAISE NOTICE but does not fetch or load IERS data. Users must
+manually download Bulletin A and call `postgis_eop_load()`. This blocks automated EOP
+refresh in production deployments.
+
+Additionally, the `postgis_eop_load()` parser has incorrect column offsets for several
+IERS finals2000A fields, which would produce wrong EOP values if data were loaded
+through the PostGIS parser directly.
+
+## What Changes
+
+### Architecture Decision: File-Based Refresh (Option D)
+
+The EOP auto-refresh is implemented on the **TimescaleDB side** using a file-based
+architecture:
+
+1. **External scheduler** (cron/systemd timer) runs `scripts/fetch_iers_eop.sh` to
+   download IERS Bulletin A (`finals2000A.all`) to a local file path
+2. **TimescaleDB background job** (`ecef_eci.refresh_eop`) reads the file via
+   `pg_read_file()`, parses it with the TimescaleDB parser (`load_eop_finals2000a`),
+   and loads into `ecef_eci.eop_data`
+3. **Cross-table sync** (`ecef_eci.sync_eop_to_postgis`) upserts from `eop_data`
+   into PostGIS's `postgis_eop` table
+
+This avoids:
+- Adding HTTP extension dependencies (`pg_curl`, `http`) to PostGIS
+- Using the PostGIS parser (which has column offset bugs)
+- Requiring superuser for HTTP access
+
+### PostGIS-Side Items (Separate from TimescaleDB Implementation)
+
+1. **Fix `postgis_eop_load()` column offsets** — The parser in `ecef_eci.sql.in` uses
+   incorrect SUBSTRING offsets for MJD (FROM 19 should be FROM 8), PM-x (FROM 35
+   should be FROM 19), and PM-y (FROM 44 should be FROM 38). UT1-UTC is correct.
+   This is a standalone bug fix, independent of the auto-refresh feature.
+
+2. **Keep placeholder `postgis_refresh_eop()` as-is** — The TimescaleDB-side job
+   handles all refresh logic. The PostGIS placeholder remains for documentation
+   and forward compatibility.
+
+## Capabilities
+
+### Unchanged Capabilities
+
+- `earth-orientation-parameters`: PostGIS's `postgis_eop` table schema and
+  `postgis_eop_interpolate()` function are unchanged. The TimescaleDB sync
+  function writes to this table using the existing schema.
+
+### Known Issue
+
+- `postgis_eop_load()` parser column offsets are incorrect. This does not affect
+  the auto-refresh pipeline (data flows through TimescaleDB's parser), but should
+  be fixed for users who load EOP data directly through PostGIS.
+
+## Impact
+
+- **No C code changes** required on PostGIS side for auto-refresh
+- **SQL bug fix** needed in `postgis/ecef_eci.sql.in` for `postgis_eop_load()` offsets
+- **Cross-repo coordination**: TimescaleDB contract updated to v0.4.0, §8.3 resolved

--- a/openspec/changes/2026-02-15-eop-auto-refresh/tasks.md
+++ b/openspec/changes/2026-02-15-eop-auto-refresh/tasks.md
@@ -1,0 +1,46 @@
+## Tasks
+
+### PostGIS Side
+
+- [ ] Fix `postgis_eop_load()` column offsets in `postgis/ecef_eci.sql.in`
+  - MJD: change `FROM 19 FOR 9` to `FROM 8 FOR 8`
+  - PM-x: change `FROM 35 FOR 9` to `FROM 19 FOR 9`
+  - PM-y: change `FROM 44 FOR 9` to `FROM 38 FOR 9`
+  - Add regression test with real IERS data snippet
+  - **Priority**: Low (TimescaleDB pipeline bypasses this parser)
+
+- [ ] Verify `postgis_eop` table schema compatibility with TimescaleDB sync
+  - Confirm columns: mjd (PK), xp, yp, dut1, dx, dy
+  - Confirm `ON CONFLICT (mjd)` works for upsert
+
+### TimescaleDB Side (Completed)
+
+- [x] Replace placeholder `refresh_eop` with production version
+  - Error handling: WARNING not EXCEPTION
+  - File validation: minimum size check
+  - Post-load staleness detection
+
+- [x] Add `sync_eop_to_postgis()` function
+  - INSERT...SELECT...ON CONFLICT from eop_data to postgis_eop
+  - Graceful skip if postgis_eop table doesn't exist
+
+- [x] Add `eop_staleness()` function
+  - Returns gap_days, is_stale, load_age_hours
+  - Configurable threshold (default 7 days)
+
+- [x] Add `setup_eop_refresh()` convenience wrapper
+  - Wraps add_job() with config construction
+
+- [x] Create `scripts/fetch_iers_eop.sh`
+  - Primary + mirror URL with fallback
+  - Atomic download (tmp + mv)
+  - File size validation
+
+- [x] Create integration tests (`test/sql/postgis_ecef_eci/eop_refresh.sql`)
+
+- [x] Update interface contract to v0.4.0, §8.3 resolved
+
+### Cross-Repo Coordination
+
+- [ ] Verify end-to-end with both extensions installed
+- [ ] Update PostGIS contract copy to v0.4.0

--- a/openspec/specs/earth-orientation-parameters/spec.md
+++ b/openspec/specs/earth-orientation-parameters/spec.md
@@ -46,7 +46,7 @@ The system SHALL provide a `postgis_eop_interpolate(epoch TIMESTAMPTZ)` function
 - **THEN** the function SHALL return NULL (not extrapolate beyond loaded data)
 
 ### Requirement: EOP refresh procedure
-The system SHALL provide a `postgis_refresh_eop()` procedure suitable for scheduling with `pg_cron` or TimescaleDB's `add_job` to periodically update EOP data.
+The system SHALL provide a `postgis_refresh_eop()` procedure suitable for scheduling with `pg_cron` or TimescaleDB's `add_job` to periodically update EOP data. A `postgis_refresh_eop(job_id INT, config JSONB)` overload SHALL also be provided for direct compatibility with TimescaleDB's `add_job()` callback signature.
 
 #### Scenario: Procedure callable by scheduler
 - **WHEN** `CALL postgis_refresh_eop()` is executed
@@ -55,6 +55,10 @@ The system SHALL provide a `postgis_refresh_eop()` procedure suitable for schedu
 #### Scenario: Compatible with TimescaleDB job scheduler
 - **WHEN** `SELECT add_job('postgis_refresh_eop', schedule_interval => INTERVAL '1 day')` is executed
 - **THEN** the job SHALL be created successfully (procedure signature is compatible with `add_job` requirements)
+
+#### Scenario: TimescaleDB add_job callback overload
+- **WHEN** TimescaleDB invokes `postgis_refresh_eop(job_id := 1000, config := '{}')` via the job scheduler callback
+- **THEN** the `(INT, JSONB)` overload SHALL execute the same EOP refresh logic as the no-argument form, ignoring the `job_id` and `config` parameters
 
 ### Requirement: EOP data validation
 The system SHALL validate EOP values during loading to prevent obviously incorrect data from being stored.

--- a/openspec/specs/ecef-coordinate-support/spec.md
+++ b/openspec/specs/ecef-coordinate-support/spec.md
@@ -63,6 +63,8 @@ Functions are classified into three behavior categories for geocentric input:
 
 The CRS family SHALL be determined by calling `lwsrid_get_crs_family()` on the geometry's SRID. A return value of `LW_CRS_GEOCENTRIC` triggers the dispatch or error behavior.
 
+> **Note (contract alignment v0.2.0):** The guard function `srid_check_crs_family_not_geocentric()` now also blocks `LW_CRS_INERTIAL` (ECI SRIDs 900001+). This means error-class spatial functions raise the same guard errors for both geocentric and inertial CRS families. See the `eci-coordinate-support` spec for details on ECI guard behavior.
+
 The `geometry → geography` cast SHALL raise a geocentric-specific error when the input geometry has a geocentric SRID, before the existing `srid_check_latlong` validation runs.
 
 #### Scenario: ST_Distance on ECEF geometries returns 3D Euclidean distance

--- a/openspec/specs/eci-coordinate-support/spec.md
+++ b/openspec/specs/eci-coordinate-support/spec.md
@@ -15,6 +15,13 @@ The system SHALL identify Earth-Centered Inertial (ECI) coordinate systems (ICRF
 - **WHEN** two geometries exist, one with an ECI SRID and one with ECEF SRID 4978
 - **THEN** the system SHALL classify them under different CRS families and prevent direct spatial operations between them without explicit transformation
 
+#### Scenario: ECI SRIDs blocked by spatial function guards
+- **WHEN** an error-class spatial function (e.g., `ST_Area`, `ST_Buffer`, `ST_Perimeter`) is called on a geometry with an ECI SRID (900001-900003)
+- **THEN** the `srid_check_crs_family_not_geocentric()` guard SHALL block the call with an error, same as for ECEF/geocentric SRIDs
+- **AND** the error message SHALL indicate that the operation is not supported for this CRS family
+
+> **Note (contract alignment v0.2.0):** The guard function `srid_check_crs_family_not_geocentric()` scope was broadened to block both `LW_CRS_GEOCENTRIC` and `LW_CRS_INERTIAL` CRS families. See the `ecef-coordinate-support` spec for the full list of error-class functions.
+
 ### Requirement: Epoch-parameterized ECI-to-ECEF transformation
 The system SHALL support transformation between ECI and ECEF frames with an epoch parameter that accounts for Earth's rotation. The epoch MAY be provided as the M coordinate of `POINT4D` geometries or as an explicit parameter to `ST_Transform`.
 

--- a/openspec/specs/sql-frame-conversion/spec.md
+++ b/openspec/specs/sql-frame-conversion/spec.md
@@ -60,11 +60,15 @@ The frame conversion functions SHALL raise a clear error when an unrecognized fr
 - **THEN** the system SHALL raise an error listing the valid frame names: 'ICRF', 'J2000', 'TEME'
 
 ### Requirement: Function volatility and parallel safety
-`ST_ECEF_To_ECI` and `ST_ECI_To_ECEF` SHALL be declared STABLE (the result depends on EOP data when available) and PARALLEL SAFE.
+`ST_ECEF_To_ECI` and `ST_ECI_To_ECEF` SHALL be declared STABLE (the result depends on EOP data when available) and PARALLEL SAFE. The epoch-parameterized `ST_Transform(geometry, integer, timestamptz)` overload SHALL also be declared STABLE (not IMMUTABLE) because its result depends on EOP table data at query time.
 
 #### Scenario: Function used in parallel query
 - **WHEN** `ST_ECEF_To_ECI` is used in a query with `parallel_setup_cost = 0` on a partitioned table
 - **THEN** the query planner SHALL be able to use parallel workers to execute the function
+
+#### Scenario: ST_Transform epoch overload is STABLE
+- **WHEN** `SELECT provolatile FROM pg_proc WHERE proname = 'st_transform' AND pronargs = 3` is queried for the `(geometry, integer, timestamptz)` overload
+- **THEN** provolatile SHALL be `'s'` (STABLE), not `'i'` (IMMUTABLE), because the result depends on EOP data loaded in `postgis_eop`
 
 ### Requirement: NULL input handling
 Frame conversion functions SHALL return NULL when the input geometry is NULL, following PostgreSQL convention for STRICT functions.

--- a/postgis/ecef_eci.sql.in
+++ b/postgis/ecef_eci.sql.in
@@ -178,13 +178,13 @@ CREATE TABLE IF NOT EXISTS postgis_eop (
 
 -- Load Earth Orientation Parameters from IERS Bulletin A fixed-width format text.
 -- Parses lines and upserts into postgis_eop table.
--- Bulletin A fixed-width columns (1-based):
---   col  8-12: year (2-digit)
---   col 13-14: month
---   col 15-16: day
---   col 19-27: MJD
---   col 35-43: x (pole, arcsec)
---   col 44-52: y (pole, arcsec)
+-- IERS finals2000A fixed-width columns (1-based):
+--   col  1- 2: year (2-digit)
+--   col  3- 4: month
+--   col  5- 6: day
+--   col  8-15: MJD
+--   col 19-27: x (pole, arcsec)
+--   col 38-46: y (pole, arcsec)
 --   col 59-68: UT1-UTC (seconds)
 CREATE OR REPLACE FUNCTION postgis_eop_load(data TEXT)
 RETURNS integer AS $$
@@ -203,11 +203,11 @@ BEGIN
 			CONTINUE;
 		END IF;
 
-		-- Try to parse MJD from columns 19-27
+		-- Parse fixed-width fields per IERS finals2000A spec
 		BEGIN
-			mjd_val := trim(substring(line FROM 19 FOR 9))::FLOAT8;
-			xp_val := trim(substring(line FROM 35 FOR 9))::FLOAT8;
-			yp_val := trim(substring(line FROM 44 FOR 9))::FLOAT8;
+			mjd_val := trim(substring(line FROM 8 FOR 8))::FLOAT8;
+			xp_val := trim(substring(line FROM 19 FOR 9))::FLOAT8;
+			yp_val := trim(substring(line FROM 38 FOR 9))::FLOAT8;
 			dut1_val := trim(substring(line FROM 59 FOR 10))::FLOAT8;
 		EXCEPTION WHEN OTHERS THEN
 			CONTINUE;

--- a/postgis/ecef_eci.sql.in
+++ b/postgis/ecef_eci.sql.in
@@ -303,6 +303,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- TimescaleDB-compatible overload: add_job() passes (job_id INT, config JSONB).
+-- The parameters are accepted but not used; they exist so that
+-- SELECT add_job('postgis_refresh_eop', schedule_interval => INTERVAL '1 day');
+-- works without an adapter wrapper.
+CREATE OR REPLACE PROCEDURE postgis_refresh_eop(job_id INT, config JSONB)
+AS $$
+BEGIN
+	CALL @extschema@.postgis_refresh_eop();
+END;
+$$ LANGUAGE plpgsql;
+
 -- Hardware acceleration feature detection
 CREATE OR REPLACE FUNCTION postgis_accel_features()
 RETURNS text

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -2994,7 +2994,7 @@ CREATE OR REPLACE FUNCTION ST_Transform(geometry,integer)
 CREATE OR REPLACE FUNCTION ST_Transform(geom geometry, to_srid integer, epoch timestamptz)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME','transform_epoch'
-	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE
+	LANGUAGE 'c' STABLE STRICT PARALLEL SAFE
 	_COST_HIGH;
 
 -- Availability: 2.3.0

--- a/regress/Makefile.in
+++ b/regress/Makefile.in
@@ -92,8 +92,12 @@ staged-install-core:
 	$(MAKE) -C ../ REGRESS=1 DESTDIR=$(REGRESS_INSTALLDIR) comments-install
 	#$(MAKE) -C ../loader REGRESS=1 DESTDIR=$(REGRESS_INSTALLDIR) install
 
+staged-install-ecef-eci:
+	$(MAKE) -C ../extensions/postgis_ecef_eci REGRESS=1 DESTDIR=$(REGRESS_INSTALLDIR) install
+
 staged-install:
 	$(MAKE) staged-install-core
+	$(MAKE) staged-install-ecef-eci
 	$(MAKE) staged-install-raster
 	$(MAKE) staged-install-topology
 	$(MAKE) staged-install-sfcgal

--- a/regress/core/ecef_eci.sql
+++ b/regress/core/ecef_eci.sql
@@ -624,5 +624,5 @@ SELECT 'same_srid_eci', ST_3DDWithin(
 -- 10. Cleanup
 --------------------------------------------
 
--- Clean up ECI SRIDs added to spatial_ref_sys
-DELETE FROM spatial_ref_sys WHERE srid IN (900001, 900002, 900003);
+-- ECI SRIDs (900001-900003) are managed by test infrastructure
+-- (loaded via ecef_eci.sql in prepare_spatial), so no cleanup needed here.

--- a/regress/core/ecef_eci.sql
+++ b/regress/core/ecef_eci.sql
@@ -1,9 +1,5 @@
 -- Tests for ECEF/ECI coordinate frame conversion and ECEF accessors
-
--- Load ECEF/ECI via extension (requires postgis extension already loaded)
-SET client_min_messages TO WARNING;
-CREATE EXTENSION IF NOT EXISTS postgis_ecef_eci;
-RESET client_min_messages;
+-- ECEF/ECI functions are loaded by the test infrastructure (run_test.pl)
 
 --------------------------------------------
 -- 1. SRID Registration Tests
@@ -581,7 +577,24 @@ SELECT 'guard_segmentize', ST_AsText(ST_Segmentize(
 -- 9.6 Geography cast on ECEF geometry should raise geocentric error
 SELECT 'guard_geog_cast', ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978)::geography;
 
--- 9.7 Negative tests: guards do NOT fire on geographic/projected input
+-- 9.7 ECI guard tests: same functions should also error on ECI input
+SELECT 'guard_eci_perimeter', ST_Perimeter(ST_SetSRID(ST_GeomFromText(
+	'POLYGON((6378137 0 0, 0 6378137 0, 0 0 6378137, 6378137 0 0))'), 900001));
+
+SELECT 'guard_eci_azimuth', ST_Azimuth(
+	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 900001),
+	ST_SetSRID(ST_MakePoint(0, 6378137, 0), 900001));
+
+SELECT 'guard_eci_project_dir', ST_AsText(ST_Project(
+	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 900001), 1000, 0.5));
+
+SELECT 'guard_eci_segmentize', ST_AsText(ST_Segmentize(
+	ST_SetSRID(ST_MakeLine(ST_MakePoint(6378137, 0, 0), ST_MakePoint(0, 6378137, 0)), 900001),
+	100000));
+
+SELECT 'guard_eci_geog_cast', ST_SetSRID(ST_MakePoint(6378137, 0, 0), 900001)::geography;
+
+-- 9.8 Negative tests: guards do NOT fire on geographic/projected input
 SELECT 'neg_perimeter', ST_Perimeter(ST_SetSRID(ST_GeomFromText(
 	'POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'), 4326)) > 0;
 SELECT 'neg_azimuth', ST_Azimuth(
@@ -592,29 +605,24 @@ SELECT 'neg_project', ST_AsText(ST_Project(
 SELECT 'neg_segmentize', ST_NPoints(ST_Segmentize(
 	ST_SetSRID(ST_MakeLine(ST_MakePoint(0, 0), ST_MakePoint(10, 10)), 4326), 1)) > 2;
 
--- 9.8 Mixed-SRID safety: ECEF vs geographic should error
+-- 9.9 Mixed-SRID safety: ECEF vs geographic should error
 SELECT 'mixed_ecef_geog', ST_3DDWithin(
 	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
 	ST_SetSRID(ST_MakePoint(0, 0, 0), 4326), 1000);
 
--- 9.9 Mixed-SRID safety: ECEF vs ECI should error
+-- 9.10 Mixed-SRID safety: ECEF vs ECI should error
 SELECT 'mixed_ecef_eci', ST_3DDWithin(
 	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 4978),
 	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 900001), 1000);
 
--- 9.10 Same-SRID ECI query should succeed
+-- 9.11 Same-SRID ECI query should succeed
 SELECT 'same_srid_eci', ST_3DDWithin(
 	ST_SetSRID(ST_MakePoint(6378137, 0, 0), 900001),
 	ST_SetSRID(ST_MakePoint(6378137, 100, 0), 900001), 1000);
 
 --------------------------------------------
--- 10. Extension Cleanup
+-- 10. Cleanup
 --------------------------------------------
 
--- Drop extension to verify clean removal (functions, tables, etc.)
-SET client_min_messages TO WARNING;
-DROP EXTENSION IF EXISTS postgis_ecef_eci CASCADE;
-RESET client_min_messages;
-
--- Clean up ECI SRIDs added to spatial_ref_sys (not tracked by extension)
+-- Clean up ECI SRIDs added to spatial_ref_sys
 DELETE FROM spatial_ref_sys WHERE srid IN (900001, 900002, 900003);

--- a/regress/core/ecef_eci_expected
+++ b/regress/core/ecef_eci_expected
@@ -64,6 +64,11 @@ ERROR:  ST_Project: Operation is not supported for geocentric (ECEF) coordinates
 ERROR:  ST_Project: Operation is not supported for geocentric (ECEF) coordinates (SRID=4978). Transform to a geographic or projected CRS first.
 ERROR:  ST_Segmentize: Operation is not supported for geocentric (ECEF) coordinates (SRID=4978). Transform to a geographic or projected CRS first.
 ERROR:  geometry::geography: Operation is not supported for geocentric (ECEF) coordinates (SRID=4978). Transform to a geographic or projected CRS first.
+ERROR:  ST_Perimeter: Operation is not supported for inertial (ECI) coordinates (SRID=900001). Transform to a geographic or projected CRS first.
+ERROR:  ST_Azimuth: Operation is not supported for inertial (ECI) coordinates (SRID=900001). Transform to a geographic or projected CRS first.
+ERROR:  ST_Project: Operation is not supported for inertial (ECI) coordinates (SRID=900001). Transform to a geographic or projected CRS first.
+ERROR:  ST_Segmentize: Operation is not supported for inertial (ECI) coordinates (SRID=900001). Transform to a geographic or projected CRS first.
+ERROR:  geometry::geography: Operation is not supported for inertial (ECI) coordinates (SRID=900001). Transform to a geographic or projected CRS first.
 neg_perimeter|t
 neg_azimuth|t
 neg_project|t

--- a/regress/core/lwgeom_regress_expected
+++ b/regress/core/lwgeom_regress_expected
@@ -13,17 +13,17 @@ BOX3D(0 0.1 -55,11 12 12)
 #3057|SRID=4326;POINTM(1 1 2)
 #3057|SRID=4326;POINT(1 1 0 0)
 #3057|SRID=4326;POINT(1 1 1 2)
-#3069|Point[S]
-#3069|LineString[S] with 2 points
-#3069|MultiPoint[S] with 1 element:   Point[S]
-#3069|MultiLineString[S] with 1 element:   LineString[S] with 2 points
-#3069|Polygon[BS] with 1 ring:    ring 0 has 5 points
+#3069|Point[S] crs_family=geographic
+#3069|LineString[S] with 2 points crs_family=geographic
+#3069|MultiPoint[S] with 1 element:   Point[S] crs_family=geographic
+#3069|MultiLineString[S] with 1 element:   LineString[S] with 2 points crs_family=geographic
+#3069|Polygon[BS] with 1 ring:    ring 0 has 5 points crs_family=geographic
 #3069|BOX(1 1,1 1)
 #3069|BOX(0 0,1 1)
 #3069|BOX(0 0,1 1)
 #3069|BOX(1 1,1 1)
 #3069|BOX(0 0,1 1)
-#2902|GeometryCollection[ZBS] with 3 elements:   Polygon[ZS] with 1 ring:    ring 0 has 5 points   Point[ZS]   MultiLineString[ZS] with 1 element:     LineString[ZS] with 2 points
+#2902|GeometryCollection[ZBS] with 3 elements:   Polygon[ZS] with 1 ring:    ring 0 has 5 points   Point[ZS]   MultiLineString[ZS] with 1 element:     LineString[ZS] with 2 points crs_family=geographic
 BoundingDiagonal1  |SRID=4326;LINESTRING(999999986991104 999999986991104,1.000000054099968e+15 1.000000054099968e+15)
 BoundingDiagonal1.1|SRID=4326;LINESTRING(999999986991104 999999986991104,1.000000054099968e+15 1.000000054099968e+15)
 BoundingDiagonal2  |SRID=4326;LINESTRING(1e+15 1e+15,1e+15 1e+15)

--- a/regress/core/regress_crs_family_expected
+++ b/regress/core/regress_crs_family_expected
@@ -2,7 +2,7 @@ CF1|geographic
 CF2|projected
 CF3|geocentric
 CF4|projected
-ERROR:  Invalid reserved SRID (999999)
+CF5|unknown
 CF6|unknown
 CF7|geographic
 CF8|geographic

--- a/regress/core/tickets_expected
+++ b/regress/core/tickets_expected
@@ -198,9 +198,9 @@ ERROR:  got NULL for SRID (500001)
 #1398b|POINT(-160.137654 77.091608)
 #1543|MULTILINESTRING((0 0,10 0,10 10,0 0),(0 0))|POLYGON((0 0,10 10,10 0,0 0))
 #1578|f|f
-#1580.1|Point[S]
+#1580.1|Point[S] crs_family=projected
 NOTICE:  #1580.2: Caught a PROJ error
-#1580.3|Point[S]
+#1580.3|Point[S] crs_family=projected
 #1596.1|public.road_pg.roads_geom SRID:3395 TYPE:POINT DIMS:2 
 ERROR:  invalid SRID: 330000 not found in spatial_ref_sys
 #1596.3|3395
@@ -209,7 +209,7 @@ ERROR:  invalid SRID: 999000 not found in spatial_ref_sys
 NOTICE:  SRID value -1 converted to the officially unknown SRID value 0
 #1596.6|public.road_pg.roads_geom SRID changed to 0
 #1596.7|0
-#1596|Point[GS]
+#1596|Point[GS] crs_family=geographic
 #1695|MULTIPOLYGON EMPTY
 #1697.1|0
 #1697.2|0
@@ -269,7 +269,7 @@ ERROR:  invalid GML representation
 #2712|LINESTRING EMPTY
 #2717|POINT(-1 -1)|POINT(3 1)|POINT(-1 -1)|POINT(1 1)|POINT(1 1)|POINT(2 2)|POINT(3 1)
 #2788|f|Self-intersection|POINT(1 1)
-#2870|Point[GS]
+#2870|Point[GS] crs_family=geographic
 #2956|t
 #2985|LINESTRING(20.951166425380894 52.398456073043555)
 #2996|247.44|247.44
@@ -280,8 +280,8 @@ ERROR:  invalid GML representation
 #3172|LINESTRING M (0 0 1,0 0 2)
 #3300|POLYGON((-71.7821 42.2622,-71.7821 42.9067,-71.029 42.9067,-71.029 42.2622,-71.7821 42.2622))
 #3355|t
-#3356|LineString[] with 2 points|LineString[GS] with 2 points|LineString[GS] with 2 points
-#3356|LineString[B] with 3 points|LineString[BGS] with 3 points|LineString[BGS] with 3 points
+#3356|LineString[] with 2 points|LineString[GS] with 2 points crs_family=geographic|LineString[GS] with 2 points crs_family=geographic
+#3356|LineString[B] with 3 points|LineString[BGS] with 3 points crs_family=geographic|LineString[BGS] with 3 points crs_family=geographic
 #3367|POLYGON EMPTY
 #3368|\x660001011fb98788d35ed6fbcdc831c580012b959f01469d8d0e9305ff8618ed08b1b607e302a614fe70bc4682b303b4379ab503a228eeb603e2138eb802900cc0b802ba04dab802b801a8840cb0229cca06f401c216f403a016ea05d0c301a8b301cc189226ac15ee27f811a029b40eac2ae00a902b8407c82b9e03d0e305801dfad3239504ce7e8d01e2f701f6019b04d1e2279bf901ff01
 #3375|GEOMETRYCOLLECTION(POINT(0 -7))

--- a/regress/hooks/hook-before-uninstall.sql
+++ b/regress/hooks/hook-before-uninstall.sql
@@ -1,2 +1,20 @@
 DROP EVENT TRIGGER IF EXISTS trg_autovac_disable;
 DROP FUNCTION IF EXISTS trg_test_disable_table_autovacuum();
+
+-- Clean up ECEF/ECI objects loaded by ecef_eci.sql during prepare_spatial()
+DROP TABLE IF EXISTS postgis_eop CASCADE;
+DROP FUNCTION IF EXISTS ST_ECEF_To_ECI(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS ST_ECI_To_ECEF(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS _postgis_ecef_to_eci_eop(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS _postgis_eci_to_ecef_eop(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS ST_ECEF_To_ECI_EOP(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS ST_ECI_To_ECEF_EOP(geometry, timestamptz, text);
+DROP FUNCTION IF EXISTS ST_ECEF_X(geometry);
+DROP FUNCTION IF EXISTS ST_ECEF_Y(geometry);
+DROP FUNCTION IF EXISTS ST_ECEF_Z(geometry);
+DROP FUNCTION IF EXISTS postgis_eop_load(text);
+DROP FUNCTION IF EXISTS postgis_eop_interpolate(timestamptz);
+DROP PROCEDURE IF EXISTS postgis_refresh_eop();
+DROP PROCEDURE IF EXISTS postgis_refresh_eop(int, jsonb);
+DROP FUNCTION IF EXISTS postgis_accel_features();
+DELETE FROM spatial_ref_sys WHERE srid IN (900001, 900002, 900003);

--- a/regress/run_test.pl
+++ b/regress/run_test.pl
@@ -1743,6 +1743,20 @@ sub prepare_spatial_extensions
 		}
 	}
 
+	# ECEF/ECI extension (always load if available)
+	{
+		my $sql = "CREATE EXTENSION IF NOT EXISTS postgis_ecef_eci";
+		$sql .= " SCHEMA " . $OPT_SCHEMA;
+
+		print "Preparing db '${DB}' using: ${sql}\n";
+
+		$cmd = "psql $psql_opts -c \"" . $sql . "\" $DB >> $REGRESS_LOG 2>&1";
+		$rv = system($cmd);
+		if ( $rv ) {
+			print "NOTICE: postgis_ecef_eci extension not available, skipping\n";
+		}
+	}
+
  	return 1;
 }
 
@@ -1783,6 +1797,12 @@ sub prepare_spatial
 		print "Loading SFCGAL into '${DB}'\n";
 		return 0 unless load_sql_file("${scriptdir}/sfcgal.sql", 1, $werror);
 		return 0 unless load_sql_file("${scriptdir}/sfcgal_comments.sql", 0, $werror);
+	}
+
+	if ( -f "${scriptdir}/ecef_eci.sql" )
+	{
+		print "Loading ECEF/ECI into '${DB}'\n";
+		return 0 unless load_sql_file("${scriptdir}/ecef_eci.sql", 1, $werror);
 	}
 
 	return 1;

--- a/regress/run_test.pl
+++ b/regress/run_test.pl
@@ -1872,6 +1872,12 @@ sub upgrade_spatial
         return 0 unless load_sql_file($script, 1);
     }
 
+    if ( -f "${STAGED_SCRIPTS_DIR}/ecef_eci_upgrade.sql" )
+    {
+        print "Upgrading ECEF/ECI\n";
+        return 0 unless load_sql_file("${STAGED_SCRIPTS_DIR}/ecef_eci_upgrade.sql", 1);
+    }
+
     return 1;
 }
 

--- a/regress/run_test.pl
+++ b/regress/run_test.pl
@@ -2120,6 +2120,10 @@ sub drop_spatial_extensions
         }
     }
 
+    # ECEF/ECI extension (always drop if present, before main postgis)
+    $cmd = "psql $psql_opts -c \"DROP EXTENSION IF EXISTS postgis_ecef_eci;\" $DB >> $REGRESS_LOG 2>&1";
+    system($cmd); # Ignore errors - extension may not be installed
+
     $cmd = "psql $psql_opts -c \"DROP EXTENSION postgis\" $DB >> $REGRESS_LOG 2>&1";
     $rv = system($cmd);
     if ( $rv ) {


### PR DESCRIPTION
## Summary

- Fix CI failures in ECEF/ECI test infrastructure: SRID 0 guard for `srid_get_crs_family`, delegate to `proj_create` path, update expected test output
- Add contract alignment changes: broaden geocentric guards to block ECI input, add `postgis_refresh_eop(INT, JSONB)` overload for TimescaleDB `add_job()`, downgrade `ST_Transform` epoch overload from IMMUTABLE to STABLE
- Add OpenSpec change set documenting the file-based EOP auto-refresh architecture and `postgis_eop_load()` parser column offset bug

## Details

### CI Fixes
- `srid_get_crs_family()` now handles SRID 0 gracefully instead of segfaulting
- Delegates unknown SRIDs to `proj_create` path for proper CRS family detection
- Updated expected output files to match corrected guard behavior

### Contract Alignment (§8.1, §8.2, §8.4)
- `srid_check_crs_family_not_geocentric()` now checks both `LW_CRS_GEOCENTRIC` and `LW_CRS_INERTIAL` — all 12 call sites automatically block ECI input from geodetic functions
- Added `postgis_refresh_eop(job_id INT, config JSONB)` overload compatible with TimescaleDB's `add_job()` signature
- `ST_Transform(geom, srid, epoch)` downgraded from IMMUTABLE to STABLE for consistency with `ST_ECEF_To_ECI`

### EOP Auto-Refresh OpenSpec
Documents the cross-repo architecture where TimescaleDB handles file-based EOP refresh. Notes the `postgis_eop_load()` parser column offset bug (MJD, PM-x, PM-y fields use wrong SUBSTRING offsets) for separate fix.

### Cross-Repo
Coordinates with TimescaleDB (`montge/timescaledb`, branch `claude/openspec-postgis-integration-cIgmI`, PR timescale/timescaledb#9268).

## Test plan

- [ ] Verify `make check` passes for `regress/core/ecef_eci.sql`
- [ ] Verify ECI input to ST_Area, ST_Buffer, ST_Perimeter, ST_Azimuth, ST_Project, ST_Segmentize raises `ERRCODE_FEATURE_NOT_SUPPORTED`
- [ ] Verify `postgis_refresh_eop(0, '{}'::jsonb)` executes without error
- [ ] Verify `ST_Transform(geom, 900001, epoch)` is STABLE (check `pg_proc.provolatile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)