### PR TITLE
GPU roadmap: precision classes, Metal SIMD ERA follow-up, multi-vendor rollout plan

### DIFF
--- a/openspec/changes/gpu-backend-precision-classes/.openspec.yaml
+++ b/openspec/changes/gpu-backend-precision-classes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/gpu-backend-precision-classes/design.md
+++ b/openspec/changes/gpu-backend-precision-classes/design.md
@@ -1,0 +1,95 @@
+## Context
+
+PostGIS has a layered hardware acceleration stack: scalar fp64, SIMD (NEON / AVX2 / AVX-512), and GPU (CUDA / ROCm / oneAPI / Metal). PR #13 (`apple-metal-gpu-backend`) shipped with a discovered constraint: Apple GPU shader cores have NO 64-bit floating-point ALUs, so the Metal backend cannot match the bit-level precision of the scalar fp64 reference. Every other backend in the stack uses fp64 hardware natively and IS bit-equivalent to the reference.
+
+To articulate this asymmetry, PR #13's design.md introduced a `FP64_NATIVE` / `FP32_ONLY` two-class precision model. The model is sound but its physical location — buried inside `specs/metal-compute-kernels/spec.md` of one specific in-flight change — makes it discoverable only by people who already know about the Metal-specific issue. Future GPU backends, reviewers of future tests, and maintainers of the dispatch layer have no clean way to find or reference the classification.
+
+This change extracts the precision class model into its own top-level capability spec so it can be linked from any backend's spec, any test's tolerance documentation, and any dispatch policy decision. It also adds a thin C-level accessor (`lwgpu_backend_precision_class(LW_GPU_BACKEND b)`) returning a compile-time constant per backend, so test code can assert the classification rather than embedding magic numbers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the `FP64_NATIVE` / `FP32_ONLY` model **the** authoritative reference, located outside any single backend's spec
+- Document each existing backend's classification in one place (scalar, NEON, AVX2, AVX-512, CUDA, ROCm, oneAPI, Metal)
+- Define the test tolerance invariant once, not per-test-file
+- Provide a tiny C accessor so future tests can verify class membership at runtime
+- Establish the dispatch policy contract (what each class MAY and MUST do)
+- Set up the surface that future backend additions (CUDA on DGX Spark, etc.) will declare against without re-deriving the model
+
+**Non-Goals:**
+- Changing any existing backend's behavior. This is documentation + a compile-time accessor.
+- Implementing a runtime registry of operations and their minimum required precision class. Out of scope; a possible future enhancement.
+- Defining additional precision classes beyond the two we have. The enum can be extended later if a third use case appears (e.g., "configurable precision" backend), but premature extension creates classification ambiguity.
+- Changing the Metal `FP32_EARTH_SCALE_TOLERANCE` value or any other tolerance. Just moving it to a shared location.
+- Touching the actual SIMD or GPU code. All changes are headers, the dispatch table file, and OpenSpec docs.
+
+## Decisions
+
+### Decision 1: New top-level capability, not a section in an existing spec
+
+**Choice:** Create a new capability `gpu-precision-classes` with its own `spec.md`. Do not add the model as a section in `gpu-transform-dispatch` or any other existing capability.
+
+**Rationale:**
+- Cross-cutting concerns deserve their own spec — they apply to multiple capabilities (any spec touching GPU dispatch references this), so co-locating them with one parent capability creates artificial coupling.
+- The precision class model is stable infrastructure (the two classes don't change as backends are added), so it makes sense as a foundational spec that other specs build on.
+- Searchability: a developer looking for "what's the precision contract" can find a top-level capability immediately, instead of navigating into a backend-specific spec.
+
+**Alternatives considered:**
+- **(A) Section in `apple-metal-gpu-backend/specs/metal-compute-kernels/spec.md`** — current state, doesn't scale to other backends.
+- **(B) Section in a hypothetical `gpu-transform-dispatch` capability** — couples the precision model to dispatch policy, which is not strictly the same concept (dispatch is about when/where; precision is about what the backend guarantees).
+- **(C) Markdown file outside OpenSpec** — loses the validation and review structure that OpenSpec provides.
+
+### Decision 2: Compile-time constant accessor, not runtime detection
+
+**Choice:** `LW_GPU_PRECISION_CLASS lwgpu_backend_precision_class(LW_GPU_BACKEND b)` returns a constant for each enum value via a switch statement. The classification is determined at the source-code level, not by querying hardware capabilities at runtime.
+
+**Rationale:**
+- For the current backends, the classification is invariant: Apple Silicon GPUs are fp32-only forever (it's a hardware decision Apple made years ago), and CUDA/ROCm/oneAPI hardware has had fp64 for decades. There is no scenario where the same `LW_GPU_BACKEND` value maps to different precision classes at runtime.
+- Compile-time classification enables test assertions like `STATIC_ASSERT(lwgpu_backend_precision_class(LW_GPU_CUDA) == LW_GPU_PRECISION_FP64_NATIVE)` if the C standard supported it (it doesn't quite, but the spirit is there).
+- A future "configurable precision" backend (e.g., a backend that exposes both fp32 and fp64 modes via different `LW_GPU_BACKEND` values) would simply have two enum entries with different classifications — still no runtime detection needed.
+
+**Alternatives considered:**
+- **(A) Runtime detection via Metal/CUDA/ROCm device queries** — overkill, and not actually different from compile-time for the current set of backends.
+- **(B) No accessor at all, just documentation** — loses the ability to write tests that fail at compile time / link time if a backend is misclassified.
+
+### Decision 3: Shared tolerance header in `cu_accel_tolerances.h`
+
+**Choice:** Create `liblwgeom/cunit/cu_accel_tolerances.h` containing `FP32_EARTH_SCALE_TOLERANCE` and (eventually) `FP64_STRICT_TOLERANCE = 1e-10`. Move the existing `FP32_EARTH_SCALE_TOLERANCE` definition out of `cu_metal.c` and into the header. Other future test files include the header.
+
+**Rationale:**
+- Multiple test files will need these constants (current Metal tests, future CUDA tests, future ROCm tests). Defining them once avoids drift.
+- A single-file location for tolerance values means future tuning (e.g., if the FP32_EARTH_SCALE_TOLERANCE turns out to be too tight or too loose for a specific operation) happens in one place.
+- Having `FP64_STRICT_TOLERANCE` and `FP32_EARTH_SCALE_TOLERANCE` side-by-side documents the contrast between the two classes' tolerance regimes.
+
+### Decision 4: Backend classification as a table in the spec
+
+**Choice:** The `gpu-precision-classes` spec includes a table with one row per current backend (scalar, NEON, AVX2, AVX-512, CUDA, ROCm, oneAPI, Metal) and columns for: precision class, hardware basis for the classification (e.g., "Apple Silicon shader cores have no fp64 ALUs"), expected error bound, and the dispatch policy that follows from the class.
+
+**Rationale:** Tables are vastly easier to scan than a paragraph per backend, and a table makes it visually obvious which backend is the outlier (Metal is the only FP32_ONLY row).
+
+## Risks / Trade-offs
+
+- **[Risk] The new accessor adds a 1-line maintenance burden when a new backend is added** — anyone adding `LW_GPU_NEW_BACKEND` to the enum must also add a case to `lwgpu_backend_precision_class()`. **Mitigation**: the switch statement uses `default: return LW_GPU_PRECISION_FP64_NATIVE` as the safe-by-default fallback for SIMD-only backends, but explicit cases for each enum value are still recommended (and a `-Wswitch` warning catches missing entries). Reviewers should flag missing classifications during code review.
+
+- **[Trade-off] Adding a placeholder accessor that nothing currently calls** — no production code uses `lwgpu_backend_precision_class()` today; only future tests will. Considered acceptable because the cost is ~25 lines of code and the alternative is "future tests have nowhere to assert against".
+
+- **[Trade-off] Duplicates the FP32_EARTH_SCALE_TOLERANCE definition during the transition** — until cu_metal.c picks up the include, the constant is defined in both places. Single commit fixes this.
+
+- **[Risk] Linking from the Metal spec to a separate capability spec** — OpenSpec has no first-class cross-spec link mechanism (just markdown links). The link from `metal-compute-kernels/spec.md` to `gpu-precision-classes/spec.md` is plain text. If the latter spec is ever renamed, the former breaks silently. **Mitigation**: tests should verify the linked spec exists at archive time. Out of scope here.
+
+## Migration Plan
+
+1. Land this change after PR #13 merges to develop. (If PR #13 is rebased or revised, this change rebases onto it.)
+2. The new capability `gpu-precision-classes` is created at change-archive time as `openspec/specs/gpu-precision-classes/spec.md`.
+3. The existing Metal spec is updated to reference the new top-level capability instead of defining its own model. The Metal spec retains a brief "Metal is FP32_ONLY because..." sentence for context, but the authoritative definitions live in the new capability.
+4. The `cu_accel_tolerances.h` header is created with `FP32_EARTH_SCALE_TOLERANCE` (and the related `FP64_STRICT_TOLERANCE` for future reference). `cu_metal.c` is updated to include the header.
+5. The accessor `lwgpu_backend_precision_class()` is added with explicit cases for every current `LW_GPU_BACKEND` enum value.
+6. No tests change behavior; the new accessor has no callers in this commit. Subsequent OpenSpec changes (e.g., the CUDA validation work for DGX Spark) will be the first consumers.
+
+**Rollback:** If the new spec or accessor causes any issue, revert this change. The Metal tests continue to pass because their tolerance definition is restored to `cu_metal.c`'s local `#define`. No runtime behavior changes.
+
+## Open Questions
+
+1. **Should the spec be named `gpu-precision-classes` or `accelerator-precision-classes`?** — Currently I'm using the former because GPU is where the classification matters in practice (every SIMD/scalar backend is FP64_NATIVE). But if a future SIMD path (e.g., a hypothetical fp16 SIMD batch) needs the same classification, the broader name would fit better. Defer until that hypothetical materializes.
+2. **Should the accessor be `static inline` in the header or out-of-line in the .c file?** — Static inline gives the compiler the ability to fold the result at every call site, which is valuable for tests that branch on classification. Out-of-line is slightly easier to debug. Recommendation: static inline.
+3. **Should this change extend to AVX/NEON/scalar dispatch precision too?** — All non-GPU backends are FP64_NATIVE so the classification is trivially "FP64_NATIVE", but the accessor `lwgpu_*` is GPU-specific. A parallel `lwaccel_backend_precision_class()` could be added but would always return FP64_NATIVE, which feels unnecessary. Leaving it out for now.

--- a/openspec/changes/gpu-backend-precision-classes/proposal.md
+++ b/openspec/changes/gpu-backend-precision-classes/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+PR #13 (`apple-metal-gpu-backend`) introduced a two-class precision model for GPU backends — `FP64_NATIVE` and `FP32_ONLY` — to articulate why Metal is the only backend that cannot be bit-equivalent to the scalar fp64 reference. The classification lives **buried inside the Metal-specific spec** (`specs/metal-compute-kernels/spec.md`), which means:
+
+1. Future GPU backends (CUDA on DGX Spark, ROCm on AMD, oneAPI on Intel) have no obvious place to declare their precision class. A reviewer of the next CUDA validation change would have to either (a) re-derive the classification from scratch or (b) chase a cross-reference into the Metal spec to find a one-paragraph definition.
+
+2. The test-tolerance invariant ("FP64_NATIVE tests use ≤ 1e-10 absolute tolerance, FP32_ONLY tests use scale-relative `max_coord × 1e-6`") is not codified anywhere reviewable. Future tests will silently use whatever tolerance the author guessed, repeating the exact bug PR #13 just fixed.
+
+3. The dispatch policy ("FP64_NATIVE backends are safe for any operation; FP32_ONLY backends require per-operation precision review") has no enforcement mechanism — it relies on humans reading design.md from one specific OpenSpec change.
+
+4. The user's stated multi-phase rollout plan (Metal → CUDA on ARM → CUDA on x86 → ROCm → oneAPI) is going to add four more backends. Each addition will need to declare its precision class. Doing that against a cross-cutting capability is dramatically cleaner than amending the Metal spec.
+
+This change formalizes the precision class concept as **its own top-level capability** so all current and future GPU backends can declare against it, the test invariants are reviewable, and the dispatch policy has a clear contract surface.
+
+## What Changes
+
+- Create a new capability `gpu-precision-classes` with an authoritative definition of `FP64_NATIVE` and `FP32_ONLY` backend classes, the per-class precision contracts, and the test-tolerance invariant
+- Document the classification of each existing backend (scalar fp64, NEON, AVX2, AVX-512, CUDA, ROCm, oneAPI, Metal) — all FP64_NATIVE except Metal which is FP32_ONLY
+- Define the dispatch-policy contract: FP64_NATIVE backends MAY be invoked for any operation gated only by performance threshold; FP32_ONLY backends MUST have per-operation review documenting that the precision contract is acceptable for the operation's domain
+- Extract the FP32_EARTH_SCALE_TOLERANCE constant from `cu_metal.c` into a shared `liblwgeom/cunit/cu_accel_tolerances.h` header so future tests for any FP32_ONLY backend can reuse the same scale-relative bound (and the value can be tuned in one place)
+- Add a placeholder `enum LW_GPU_PRECISION_CLASS { LW_GPU_PRECISION_FP64_NATIVE = 0, LW_GPU_PRECISION_FP32_ONLY = 1 }` and `LW_GPU_PRECISION_CLASS lwgpu_backend_precision_class(LW_GPU_BACKEND b)` accessor in `liblwgeom/lwgeom_gpu.h`. The accessor returns a constant per backend for now; in the future it could become a runtime query if needed (e.g., for a hypothetical "configurable precision" backend)
+- Update the Metal `specs/metal-compute-kernels/spec.md` to reference the new top-level capability instead of duplicating the FP32_ONLY definition inline
+- Update the existing `apple-metal-gpu-backend` design.md Decision 9 to point at the new capability spec as the authoritative source
+
+## Capabilities
+
+### New Capabilities
+
+- `gpu-precision-classes`: Authoritative cross-backend definition of GPU precision classes (`FP64_NATIVE`, `FP32_ONLY`), per-class contracts (absolute/relative error bounds, dispatch policy, test tolerance invariants), and the classification of each backend currently in the GPU abstraction. Provides a single reviewable contract surface for all current and future backends.
+
+### Modified Capabilities
+
+None directly. The Metal spec gets light updates to reference the new top-level capability instead of defining its own precision model, but this is a documentation refactor — no behavior changes.
+
+## Impact
+
+- **Code**: small additions only.
+  - `liblwgeom/lwgeom_gpu.h`: new enum + accessor declaration (~10 lines)
+  - `liblwgeom/lwgeom_gpu.c`: accessor implementation (~15 lines, just a constant return per backend)
+  - `liblwgeom/cunit/cu_accel_tolerances.h`: new header with FP32_EARTH_SCALE_TOLERANCE and (future) other shared tolerance constants
+  - `liblwgeom/cunit/cu_metal.c`: include the new header instead of defining the constant locally
+- **Specs**: new `openspec/specs/gpu-precision-classes/spec.md` (after this change archives) and a small update to the Metal change's spec to reference it
+- **No behavior change.** This is documentation + a small accessor that returns a compile-time constant per backend. Existing tests and dispatch logic are untouched.
+- **Cross-backend leverage**: the next time a GPU backend gets validated (CUDA on DGX Spark is the most likely first), the validator can write `CU_ASSERT(lwgpu_backend_precision_class(LW_GPU_CUDA) == LW_GPU_PRECISION_FP64_NATIVE)` and reference the established contract instead of re-litigating the precision question.
+
+## Open Questions
+
+1. **Should the dispatch layer enforce the precision policy at runtime?** — E.g., when a future operation registers itself, it could declare a "minimum required precision class" and the dispatch layer would refuse to invoke an FP32_ONLY backend for an operation that requires FP64. Out of scope for this change because no such operation registry exists yet, but it would be the natural next step if precision policy violations become a maintenance problem.
+2. **Are there any backends that need a third class?** — A hypothetical "configurable" class where a single physical backend exposes both fp32 and fp64 modes via a runtime flag (some Intel iGPUs work this way via `cl_khr_fp64`, and CUDA can run kernels at fp32 for speed even when fp64 is available). For now, two classes cover all current and near-term backends; the enum can be extended later without breaking existing classifications.
+3. **Should the precision class affect the dispatch threshold?** — FP32_ONLY backends have an inherent precision cost that scales with input magnitude, so it might make sense to apply a stricter threshold (or refuse dispatch entirely) for inputs at very large magnitudes. Currently the Metal `effective_gpu_threshold()` applies a uniform 5x multiplier; a magnitude-aware variant could be a future enhancement.

--- a/openspec/changes/gpu-backend-precision-classes/specs/gpu-precision-classes/spec.md
+++ b/openspec/changes/gpu-backend-precision-classes/specs/gpu-precision-classes/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Two precision classes for GPU backends
+
+The PostGIS GPU abstraction layer SHALL classify every GPU backend into one of two precision classes:
+
+- **`FP64_NATIVE`** — The backend's compute hardware exposes 64-bit IEEE 754 double-precision floating-point operations. Kernel arithmetic uses `double` throughout. Kernel output SHALL be bit-identical to the scalar fp64 reference implementation within the rounding error of normal fp64 arithmetic.
+- **`FP32_ONLY`** — The backend's compute hardware exposes only 32-bit IEEE 754 single-precision floating-point operations. Kernel arithmetic uses `float` throughout. Kernel output SHALL satisfy a bounded absolute error contract proportional to input coordinate magnitude.
+
+The classification SHALL be determined at the source-code level for each backend and SHALL NOT change at runtime for the same `LW_GPU_BACKEND` enum value. If a future use case requires a backend that exposes both fp32 and fp64 modes, that backend SHALL be represented by two separate enum values, each with its own classification.
+
+#### Scenario: Each existing backend has exactly one precision class
+
+- **WHEN** the `LW_GPU_BACKEND` enum is enumerated in `liblwgeom/lwgeom_gpu.h`
+- **THEN** the following classifications SHALL hold:
+
+  | Backend           | Enum value          | Class          | Hardware basis                                                                 |
+  |-------------------|---------------------|----------------|--------------------------------------------------------------------------------|
+  | scalar fp64       | (not in `LW_GPU_BACKEND`; treated as fp64 reference) | `FP64_NATIVE` | C `double` on host CPU                                                         |
+  | NEON              | (not in `LW_GPU_BACKEND`; SIMD layer) | `FP64_NATIVE` | NEON `float64x2_t` is bit-exact fp64 by Arm spec                                |
+  | AVX2              | (not in `LW_GPU_BACKEND`; SIMD layer) | `FP64_NATIVE` | AVX2 `__m256d` is bit-exact fp64 by Intel spec                                  |
+  | AVX-512           | (not in `LW_GPU_BACKEND`; SIMD layer) | `FP64_NATIVE` | AVX-512 `__m512d` is bit-exact fp64 by Intel spec                               |
+  | CUDA              | `LW_GPU_CUDA`       | `FP64_NATIVE`  | All NVIDIA discrete GPUs since Tesla (2008) have fp64 ALUs (variable throughput) |
+  | ROCm/HIP          | `LW_GPU_ROCM`       | `FP64_NATIVE`  | All AMD GCN/CDNA GPUs have fp64 ALUs                                           |
+  | oneAPI/SYCL       | `LW_GPU_ONEAPI`     | `FP64_NATIVE`  | Intel data-center GPUs (Ponte Vecchio, etc.) have fp64; consumer iGPU support varies but the backend is classified as FP64_NATIVE |
+  | Apple Metal       | `LW_GPU_METAL`      | `FP32_ONLY`    | Apple Silicon GPU shader cores have NO 64-bit floating-point ALUs in any generation (M1–M4, all A-series). MSL does not expose `double` as a compute type in any version. |
+
+- **AND** the only backend currently classified as `FP32_ONLY` SHALL be Metal
+- **AND** any future GPU backend addition SHALL declare its classification in the same table and add a corresponding case to `lwgpu_backend_precision_class()` (see the accessor requirement below)
+
+### Requirement: Per-class precision contracts
+
+Each precision class SHALL have a documented absolute and relative error bound, equivalence guarantee against the scalar fp64 reference, and dispatch policy guideline. Tests for any backend SHALL use a tolerance appropriate to the backend's class.
+
+| Class          | Absolute error bound                              | Relative error bound | Equivalence to scalar fp64 reference          | Dispatch policy                                                  |
+|----------------|---------------------------------------------------|----------------------|-----------------------------------------------|------------------------------------------------------------------|
+| `FP64_NATIVE`  | ≤ fp64 ULP of each operand (typically `≪ 1 mm` at Earth scale) | ≤ `2^{-52}` (~2.2e-16) | Bit-identical within fp64 rounding             | Safe for all operations; gated only by performance threshold      |
+| `FP32_ONLY`    | ≤ `max_coord × 1e-6` (~6 m at Earth-scale ECEF, typically 1–2 m worst case) | ≤ `2^{-20}` (~1e-6)  | NOT bit-identical                              | Opt-in per operation; each new operation requires precision review |
+
+#### Scenario: FP64_NATIVE test tolerance
+
+- **WHEN** a regression or CUnit test compares an `FP64_NATIVE` backend's output to the scalar fp64 reference
+- **THEN** the absolute tolerance SHALL be ≤ `1e-10` (a small constant absolute value, NOT scale-relative, because fp64 ULPs at Earth-scale ECEF are well below 1 nm)
+- **AND** the test SHALL be allowed to fail if the difference exceeds this tolerance
+
+#### Scenario: FP32_ONLY test tolerance
+
+- **WHEN** a regression or CUnit test compares an `FP32_ONLY` backend's output to the scalar fp64 reference
+- **THEN** the absolute tolerance SHALL be `max_coord × 1e-6` where `max_coord` is the maximum absolute coordinate magnitude in the input (e.g., for Earth-scale ECEF inputs at ~6.4e6 m, the tolerance is ~6.4 m)
+- **AND** the test SHALL use the shared constant `FP32_EARTH_SCALE_TOLERANCE` from `liblwgeom/cunit/cu_accel_tolerances.h` for any test fixture using Earth-scale inputs (the standard fixture from `bench_helpers.h` is Earth-scale)
+- **AND** the test SHALL NOT use the FP64_NATIVE tolerance (`≤ 1e-10`) because that bound is physically impossible for float32 kernels at Earth-scale magnitudes
+
+#### Scenario: Adding a new operation to an FP32_ONLY backend requires review
+
+- **WHEN** a contributor proposes adding a new dispatched operation to an `FP32_ONLY` backend (currently only Metal, via `lwgeom_accel.c` operation routing)
+- **THEN** the change SHALL include a precision analysis demonstrating that the operation's precision cost (typically 1–2 m at Earth scale) is acceptable for the operation's application domain
+- **AND** the change SHALL update the per-operation routing table in `lwgeom_accel.c` only after the precision analysis is reviewed
+- **AND** operations requiring sub-meter precision (property boundary transforms, surveying) SHALL NOT be added to `FP32_ONLY` dispatch paths
+
+### Requirement: Compile-time accessor for backend precision class
+
+The system SHALL provide a C accessor `lwgpu_backend_precision_class(LW_GPU_BACKEND b)` that returns the precision class of a backend as a compile-time-constant value of type `LW_GPU_PRECISION_CLASS`.
+
+The enum SHALL be defined in `liblwgeom/lwgeom_gpu.h`:
+
+```c
+typedef enum
+{
+    LW_GPU_PRECISION_FP64_NATIVE = 0,
+    LW_GPU_PRECISION_FP32_ONLY   = 1
+} LW_GPU_PRECISION_CLASS;
+```
+
+The accessor SHALL be implemented as a `static inline` function in `liblwgeom/lwgeom_gpu.h` (or equivalent compile-time mechanism) so the compiler can fold the result at every call site.
+
+#### Scenario: Accessor returns FP32_ONLY only for Metal
+
+- **WHEN** `lwgpu_backend_precision_class(LW_GPU_METAL)` is called
+- **THEN** it SHALL return `LW_GPU_PRECISION_FP32_ONLY`
+- **WHEN** the same accessor is called with `LW_GPU_NONE`, `LW_GPU_CUDA`, `LW_GPU_ROCM`, or `LW_GPU_ONEAPI`
+- **THEN** it SHALL return `LW_GPU_PRECISION_FP64_NATIVE`
+
+#### Scenario: Adding a new backend requires updating the accessor
+
+- **WHEN** a future change adds a new value to the `LW_GPU_BACKEND` enum
+- **THEN** the same change SHALL add a corresponding case to `lwgpu_backend_precision_class()` returning the appropriate class for that backend
+- **AND** the build SHALL produce a `-Wswitch` warning if the new enum value is added without a matching switch case in the accessor (relying on the compiler's switch-case completeness check)
+
+#### Scenario: Tests can assert classification at runtime
+
+- **WHEN** a CUnit test for any backend wants to verify the backend's precision class
+- **THEN** the test SHALL be able to write `CU_ASSERT_EQUAL(lwgpu_backend_precision_class(LW_GPU_CUDA), LW_GPU_PRECISION_FP64_NATIVE)` and have the assertion succeed
+- **AND** if the classification is ever changed in the source, the test SHALL fail at runtime, alerting the maintainer
+
+### Requirement: Shared tolerance constants for accelerator tests
+
+The system SHALL provide a shared header `liblwgeom/cunit/cu_accel_tolerances.h` containing the standard tolerance constants used by accelerator regression and CUnit tests. The header SHALL define at minimum:
+
+- `FP32_EARTH_SCALE_TOLERANCE`: scale-relative tolerance (`6378137.0 * 1e-6` ≈ 6.4 m) for Earth-scale FP32_ONLY backend tests
+- `FP64_STRICT_TOLERANCE`: small absolute tolerance (`1e-10`) for FP64_NATIVE backend tests
+
+#### Scenario: cu_metal.c uses the shared header
+
+- **WHEN** `liblwgeom/cunit/cu_metal.c` references `FP32_EARTH_SCALE_TOLERANCE`
+- **THEN** the constant SHALL be obtained via `#include "cu_accel_tolerances.h"`, NOT a local `#define`
+- **AND** the local `#define FP32_EARTH_SCALE_TOLERANCE ...` in cu_metal.c SHALL be removed
+
+#### Scenario: Future test files reuse the shared constants
+
+- **WHEN** a future test file (e.g., `cu_cuda.c` for CUDA validation) is added
+- **THEN** it SHALL include `cu_accel_tolerances.h` for its tolerance constants instead of defining its own
+- **AND** if a new tolerance constant is needed (e.g., `FP32_LOCAL_SCALE_TOLERANCE` for tests using small coordinates), it SHALL be added to the shared header so all backends can use it

--- a/openspec/changes/gpu-backend-precision-classes/tasks.md
+++ b/openspec/changes/gpu-backend-precision-classes/tasks.md
@@ -1,0 +1,43 @@
+## 1. New capability spec
+
+- [ ] 1.1 (Done by this OpenSpec change at archive time) The capability `gpu-precision-classes` is created at `openspec/specs/gpu-precision-classes/spec.md` from the spec delta in this change
+
+## 2. Header additions
+
+- [ ] 2.1 Add `LW_GPU_PRECISION_CLASS` enum to `liblwgeom/lwgeom_gpu.h` with values `LW_GPU_PRECISION_FP64_NATIVE = 0` and `LW_GPU_PRECISION_FP32_ONLY = 1`
+- [ ] 2.2 Add `static inline LW_GPU_PRECISION_CLASS lwgpu_backend_precision_class(LW_GPU_BACKEND b)` to `liblwgeom/lwgeom_gpu.h` with explicit case for each existing enum value: NONE/CUDA/ROCM/ONEAPI return FP64_NATIVE, METAL returns FP32_ONLY
+- [ ] 2.3 Add a comment block above the accessor pointing readers to the `gpu-precision-classes` capability spec for the authoritative definitions
+
+## 3. Shared tolerance header
+
+- [ ] 3.1 Create `liblwgeom/cunit/cu_accel_tolerances.h` containing `FP32_EARTH_SCALE_TOLERANCE` (computed as `6378137.0 * 1e-6`) and `FP64_STRICT_TOLERANCE` (`1e-10`)
+- [ ] 3.2 Add a header comment explaining the rationale (cross-backend consistency, single point of tuning) and pointing at the `gpu-precision-classes` capability spec
+- [ ] 3.3 Update `liblwgeom/cunit/cu_metal.c` to `#include "cu_accel_tolerances.h"` and remove the local `#define FP32_EARTH_SCALE_TOLERANCE`
+
+## 4. Metal spec cross-reference update
+
+- [ ] 4.1 In `openspec/changes/apple-metal-gpu-backend/specs/metal-compute-kernels/spec.md`, replace the standalone "Metal backend precision class" requirement with a reference to the new `gpu-precision-classes` capability. Keep a one-paragraph context note ("Metal is FP32_ONLY because Apple GPU shader cores have no fp64 ALUs; see gpu-precision-classes spec for the authoritative model") but remove the duplicated definition.
+- [ ] 4.2 In `openspec/changes/apple-metal-gpu-backend/design.md` Decision 9, replace the inline class definitions with a one-line "see gpu-precision-classes capability spec" reference. Keep the Metal-specific rationale (why hardware forces fp32) but defer the class definitions to the new spec.
+
+## 5. Verification
+
+- [ ] 5.1 Run `openspec validate gpu-backend-precision-classes` and confirm valid
+- [ ] 5.2 Run `openspec validate apple-metal-gpu-backend` after the cross-reference updates and confirm still valid
+- [ ] 5.3 Build the project (`make -j2`) and confirm the new header changes compile cleanly
+- [ ] 5.4 Run `cu_tester metal` and confirm all 6 existing tests still pass with the tolerance now coming from the shared header
+- [ ] 5.5 (Optional verification) Add one test assertion `CU_ASSERT_EQUAL(lwgpu_backend_precision_class(LW_GPU_METAL), LW_GPU_PRECISION_FP32_ONLY)` to `test_metal_init` in cu_metal.c to demonstrate the accessor in action -- if the test passes, the cross-backend infrastructure is working as designed
+
+## 6. Merge and archive
+
+- [ ] 6.1 Open implementation PR from a future branch (e.g., `feature/gpu-precision-classes-impl`) to fork develop. The PR includes the header additions, shared tolerance header, Metal spec cross-reference updates, and the verification test.
+- [ ] 6.2 Wait for CI green
+- [ ] 6.3 Merge to develop
+- [ ] 6.4 Archive this OpenSpec change via `openspec archive gpu-backend-precision-classes` -- this creates `openspec/specs/gpu-precision-classes/spec.md` from the deltas in this change
+
+## 7. Follow-up consumers
+
+After this change archives, future OpenSpec changes that add new GPU backends or new tests SHOULD reference the `gpu-precision-classes` capability spec rather than defining their own precision model. Specifically:
+
+- [ ] 7.1 (Future) `cuda-gpu-validation-on-arm` (DGX Spark): include `cu_accel_tolerances.h`, declare CUDA as FP64_NATIVE, use `FP64_STRICT_TOLERANCE`
+- [ ] 7.2 (Future) Any new ROCm or oneAPI validation change: same pattern
+- [ ] 7.3 (Future) Any operation registry for runtime precision policy enforcement: build on the `LW_GPU_PRECISION_CLASS` accessor as the primitive

--- a/openspec/changes/metal-simd-era-precompute/.openspec.yaml
+++ b/openspec/changes/metal-simd-era-precompute/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/metal-simd-era-precompute/design.md
+++ b/openspec/changes/metal-simd-era-precompute/design.md
@@ -1,0 +1,90 @@
+## Context
+
+PR #13 (`apple-metal-gpu-backend`) shipped the Metal backend with a correct but slow `rotate_z_m_epoch` path. The correctness fix moved the Earth Rotation Angle computation from the GPU kernel (where it produced ~900 km of error per point because float32 could not represent decimal-year epochs precisely enough) to a serial fp64 loop on the host. Benchmarks on Apple A18 Pro at 500K points:
+
+| Path                                           | Throughput   |
+|------------------------------------------------|--------------|
+| Scalar fp64 (`ptarray_rotate_z_m_epoch_scalar`) | ~58 Mpts/s   |
+| NEON fp64 (`ptarray_rotate_z_m_epoch_neon`)     | ~76 Mpts/s   |
+| Metal fp32 with serial host ERA precompute      | ~70 Mpts/s   |
+| Metal fp32 with **SIMD host ERA precompute**    | ~130 Mpts/s (target) |
+
+The serial loop in `lwgpu_metal_rotate_z_m_epoch()` runs at ~58–60 Mpts/s (essentially the scalar fp64 throughput minus the GPU dispatch cost). NEON's 2-wide `float64x2_t` ERA computation runs at ~76 Mpts/s by itself; reused as a thetas-only helper (without the rotation step) it should run at roughly twice that — ~150 Mpts/s — because it's doing half the work per loop iteration. The GPU dispatch + rotate adds ~1 ms per call regardless of point count, so for 500K points the GPU portion is amortized to ~2 Mpts/s of overhead.
+
+Combined throughput estimate: `1 / (1/150 + 1/very-large) ≈ 130 Mpts/s` for the SIMD-host + GPU-rotate path, restoring Metal as a clear ~1.7× win over NEON.
+
+The existing NEON file `liblwgeom/accel/rotate_z_neon.c` already contains the ERA computation in 2-wide intrinsic form. Splitting it into a thetas-only helper is a refactor of existing logic, not new SIMD code. Risk is low.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore Metal `rotate_z_m_epoch` as a clear throughput win (≥1.5× NEON) at the existing 50K dispatch threshold on Apple A18 Pro
+- Reuse the existing NEON ERA computation logic (no new SIMD intrinsics needed beyond what `rotate_z_neon.c` already has)
+- Keep the precision contract bit-identical to PR #13: thetas are computed in fp64 and narrowed to float exactly once per point, matching the scalar reference within the FP32_EARTH_SCALE_TOLERANCE
+- Add benchmark instrumentation that breaks down rotate_z_m_epoch into "host ERA precompute" vs "GPU kernel" so future tuning has visibility
+- Add a new CUnit test that explicitly exercises the SIMD-accelerated path and not the scalar fallback
+
+**Non-Goals:**
+- Implementing AVX2 or AVX-512 variants of the ERA helper. Apple Silicon is the only platform where Metal matters; AVX would only be exercised on (discontinued) Intel Macs or in cross-build tests. A scalar fallback covers correctness on non-NEON hosts.
+- Implementing on-GPU double-single (df64) precision emulation. Out of scope; tracked as a hypothetical future change in the multi-vendor-gpu-rollout roadmap.
+- Re-enabling Metal dispatch for `rotate_z_uniform` or `rad_convert`. Both are correctly bandwidth-bound and NEON wins; the dispatch gating in `lwgeom_accel.c` should remain.
+- Re-tuning the `effective_gpu_threshold()` 5x multiplier. May be appropriate after this change lands but should be a separate focused change with its own benchmark data.
+- Touching the CUDA, ROCm, oneAPI backends. Those are FP64_NATIVE and don't have this precision/parallelism tradeoff.
+
+## Decisions
+
+### Decision 1: New helper, not a refactor of existing rotate_z_m_epoch_neon
+
+**Choice:** Add a new function `lwgeom_accel_era_thetas_neon(const double *m_in, size_t stride_doubles, uint32_t npoints, size_t m_offset, int direction, float *thetas_out)` in a new file `liblwgeom/accel/era_thetas_neon.c`. The existing `ptarray_rotate_z_m_epoch_neon()` is left untouched.
+
+**Rationale:** The existing NEON function does ERA + rotation in a single fused loop, which is optimal when the caller wants both. Splitting it into two phases would force everyone (including the standalone NEON path used when GPU is unavailable) to make two passes over the data — half a regression for the existing code path to fix the new one. A separate helper specifically for the GPU-feeding case keeps both paths at their optimum.
+
+**Alternatives considered:**
+- **(A) Refactor existing function with an output-mode flag.** Adds branching to a hot loop, slightly worse codegen, awkward API.
+- **(B) Inline the ERA-only loop in `gpu_metal.m` directly.** Couples GPU code to NEON intrinsics; harder to test independently; not portable to future SIMD backends.
+
+### Decision 2: Reuse `lwgeom_accel.h` dispatch table
+
+**Choice:** Add a new function-pointer field `era_thetas` to the existing `LW_ACCEL_DISPATCH` struct in `liblwgeom/lwgeom_accel.h`. The existing `lwaccel_init()` function populates the field with the NEON variant, AVX2 variant (when built), or scalar fallback based on the same CPU detection it already does.
+
+**Rationale:** The dispatch table is the established pattern for runtime SIMD selection. `gpu_metal.m` calls `lwaccel_get()->era_thetas(...)` and gets the right variant for the build/host. No new infrastructure needed.
+
+### Decision 3: Output buffer ownership
+
+**Choice:** The caller (`lwgpu_metal_rotate_z_m_epoch`) allocates the `float *thetas` buffer and passes it to the helper. The helper writes into the caller's buffer and does not allocate. This matches the existing `ptarray_*` SIMD function conventions.
+
+**Rationale:** Keeps allocation policy at the dispatch site (where lifetime is clear) and avoids hidden mallocs in the inner loop. The SIMD helper can be unit-tested by passing a stack-allocated buffer.
+
+### Decision 4: Direction parameter handling
+
+**Choice:** The helper takes `int direction` and applies the sign multiplication inside the SIMD loop, not on the host pre/post. Passing `direction = -1` flips the sign of every reduced theta before writing it to the output buffer.
+
+**Rationale:** Mirrors what `gpu_metal.m`'s current serial loop does (and what `lweci_earth_rotation_angle` does in the scalar reference). Applying direction inside the SIMD loop costs one negate per lane, negligible cost.
+
+### Decision 5: Bench instrumentation breakdown
+
+**Choice:** `bench_metal.c` adds a new "rotate_z_m_epoch_breakdown" benchmark mode (or sub-output) that times the host ERA precompute and the GPU kernel dispatch+execute as separate phases, in addition to the existing wall-clock total. CSV output gains two new columns: `host_era_us` and `gpu_kernel_us`.
+
+**Rationale:** Without the breakdown, future regressions could hide in either phase. Reviewers can see at a glance whether the SIMD ERA helper is doing its job.
+
+## Risks / Trade-offs
+
+- **[Risk] SIMD ERA helper bug produces wrong thetas silently** → mitigated by the new CUnit test that compares Metal output (with SIMD helper in the dispatch path) against scalar reference within FP32_EARTH_SCALE_TOLERANCE. The existing tests would also catch any regression but the new dedicated test makes the assertion specific.
+- **[Risk] NEON `float64x2_t` precision differs from scalar fp64 by more than 1 ULP** → not actually a risk in practice (NEON `float64x2_t` is bit-exact fp64 by spec), but the test catches it if some compiler bug exists.
+- **[Trade-off] Two separate NEON code paths for ERA computation** (the existing fused `rotate_z_m_epoch_neon` and the new thetas-only helper). Slight code duplication. Considered acceptable because the alternatives (refactor with mode flag, or inline in gpu_metal.m) are worse on different axes.
+- **[Trade-off] Adds an internal helper that's only used by Metal** for now. If a future GPU backend (e.g., a hypothetical mobile GPU with no fp64) needs the same precompute, the helper is already in the dispatch table and reusable.
+
+## Migration Plan
+
+1. Land this change after PR #13 merges to develop. (If PR #13 is rebased or revised, this change rebases onto it.)
+2. Run `cu_tester metal` and `bench_metal` locally on Apple A18 Pro to verify both correctness and the target throughput.
+3. If the target throughput (≥130 Mpts/s at 500K) is missed by more than 10%, investigate whether the SIMD helper is being selected and whether the GPU dispatch overhead is higher than expected. Do not merge until the perf goal is met or explicitly waived.
+4. Update `effective_gpu_threshold()` documentation comment in `lwgeom_accel.c` with the new measured Metal performance, but do NOT change the 5× multiplier in this commit (separate change if appropriate).
+5. Mark the *Trade-off: Host-side ERA precomputation serializes the hot path* entry in `apple-metal-gpu-backend/design.md` as resolved.
+
+**Rollback:** If the SIMD helper has unexpected issues, revert this change. `gpu_metal.m` falls back to the scalar serial loop (the state after PR #13), which is correct but slow. No data corruption risk because the precision contract is unchanged.
+
+## Open Questions
+
+1. **Should the new helper also produce the per-point `cos_t` and `sin_t` instead of the raw theta?** — Could save the GPU one cos/sin call per point but adds CPU work. Defer until we have a benchmark showing it's worthwhile.
+2. **Can the same SIMD helper apply to a future CUDA-on-ARM scenario** (DGX Spark)? CUDA's `gpu_cuda.cu` is FP64_NATIVE so the precision concern doesn't apply, but the SIMD helper might still be a perf win for very large arrays where moving fp64 epochs over PCIe is slower than computing them on-host. Out of scope here, flagged for the multi-vendor-gpu-rollout roadmap.

--- a/openspec/changes/metal-simd-era-precompute/proposal.md
+++ b/openspec/changes/metal-simd-era-precompute/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The Apple Metal GPU backend's `rotate_z_m_epoch` operation regressed from a (false) ~190 Mpts/sec at 500K points to a real ~70 Mpts/sec after PR #13 fixed the float32 precision bug. The fix moved Earth Rotation Angle (ERA) computation from the GPU kernel to a host-side serial fp64 loop, which is now the throughput bottleneck. NEON does the same work in 2-wide `float64x2_t` SIMD and ends up roughly tied with Metal (76 Mpts/s vs 70 Mpts/s) — defeating the entire purpose of GPU dispatch for this operation.
+
+The fix is well-understood and the cost is modest: parallelize the host-side ERA precompute using SIMD intrinsics so the CPU does the ERA work in 2 (NEON) or 4 (AVX2) lanes per iteration instead of one. The reduced thetas array can then be passed to the Metal kernel as before, and the GPU does what it's actually good at — running thousands of cos/sin/multiply/add operations in parallel.
+
+This is the smallest change that restores Metal as a real throughput win for `rotate_z_m_epoch` without re-introducing the precision bug. Future work (df64 emulation, on-GPU ERA with split coordinates, etc.) is still possible but not required.
+
+## What Changes
+
+- Add a new helper `lwgeom_accel_era_thetas_neon()` (and `_avx2`, `_scalar` fallbacks) in `liblwgeom/accel/` that takes an input array of doubles (the M-epoch column) and writes a parallel float array of pre-reduced rotation angles ready for Metal dispatch
+- Add a corresponding entry in the `LW_ACCEL_DISPATCH` table (`liblwgeom/lwgeom_accel.h`) so the dispatch layer picks the right SIMD variant at runtime based on detected CPU features
+- Refactor `lwgpu_metal_rotate_z_m_epoch()` in `liblwgeom/accel/gpu_metal.m` to call the dispatch table's ERA-thetas helper instead of doing the computation inline. The Metal kernel signature does NOT change — it still takes 3 buffers (data, params, thetas) at the same buffer indices.
+- Add a new CUnit test `test_metal_rotate_z_m_epoch_simd_era` in `liblwgeom/cunit/cu_metal.c` that exercises the SIMD-accelerated path explicitly and verifies output matches the scalar reference within the existing `FP32_EARTH_SCALE_TOLERANCE` (~6.4 m for Earth-scale ECEF)
+- Add benchmark instrumentation in `liblwgeom/bench/bench_metal.c` to break down the rotate_z_m_epoch timing into "ERA precompute (host)" vs "GPU kernel (device)" so future optimization can target the right phase
+- Update the `apple-metal-gpu-backend` design.md *Trade-offs* section to mark the "Host-side ERA precomputation serializes the hot path" risk as resolved, with the new benchmark numbers
+- Update `lwgeom_accel.c`'s comment block on `effective_gpu_threshold()` with the new measured crossover (Metal should now win at the existing 50K threshold by a healthy margin, not by 8% margin)
+
+## Capabilities
+
+### New Capabilities
+
+None. The SIMD ERA helper is an internal implementation detail of the existing acceleration dispatch, not a new user-facing capability.
+
+### Modified Capabilities
+
+- `simd-transform-acceleration`: gains a new dispatch entry for `era_thetas` (the SIMD ERA precompute helper). The capability already covers SIMD-accelerated coordinate transforms; this adds one more operation to that surface. The existing dispatch detection logic (NEON / AVX2 / AVX-512 / scalar) is reused.
+
+## Impact
+
+- **Code**: new file `liblwgeom/accel/era_thetas_neon.c` (and conditional `era_thetas_avx2.c` for x86-64); new function in `liblwgeom/accel/rotate_z_common.h`; modified `liblwgeom/lwgeom_accel.h` (dispatch table entry); modified `liblwgeom/lwgeom_accel.c` (dispatch initialization); modified `liblwgeom/accel/gpu_metal.m` (call the dispatch helper instead of inline serial loop); modified `liblwgeom/cunit/cu_metal.c` (new test); modified `liblwgeom/bench/bench_metal.c` (timing breakdown).
+- **Build system**: new files added to `liblwgeom/Makefile.in` under the existing SIMD compilation rules.
+- **Performance**: target throughput at 500K points: Metal `rotate_z_m_epoch` ≥ 130 Mpts/s on A18 Pro (1.7× current 70 Mpts/s, 1.7× NEON 76 Mpts/s). On larger/newer Apple GPUs the relative win should be larger because the GPU portion scales while the SIMD-accelerated CPU portion scales linearly with cores.
+- **Precision contract**: unchanged. Still FP32_ONLY at the kernel boundary; the SIMD helper computes thetas in fp64 (same `lweci_*` formulas as the scalar reference) and narrows to float exactly once per point. The existing `FP32_EARTH_SCALE_TOLERANCE` test bound applies.
+- **Dispatch threshold**: may be re-tuned downward (from current 50K) once the SIMD ERA precompute lands and the crossover point shifts. Out of scope for this change but a likely follow-up.
+- **No upstream PostGIS dependency changes** and **no new external dependencies**.
+
+## Resolved Questions
+
+1. **Why not df64 (double-single) arithmetic in the kernel?** — Considered. Estimated 4× slowdown per kernel thread vs raw float32 on the GPU side, which would still be slower than this SIMD-host approach for the M-epoch operation, AND would require maintaining a non-trivial compensated-arithmetic kernel implementation. SIMD-on-host is simpler, faster, and reuses existing well-tested NEON code paths. df64 remains a future option for operations where the host-precompute pattern doesn't apply.
+2. **Why not local origin translation?** — Considered. Works for spatially clustered inputs but not for globally distributed ECI/ECEF data, and requires bookkeeping in the dispatch layer. The SIMD-host approach is universal and doesn't assume input clustering.
+3. **Why a new helper instead of reusing `ptarray_rotate_z_m_epoch_neon`?** — The existing NEON function does *both* ERA computation and rotation in a single loop. Reusing it would require splitting it into two phases (ERA only, then rotation only) and threading state between them. Cleaner to add a new helper that just produces the thetas array, keeping the existing `ptarray_rotate_z_m_epoch_neon` untouched as the standalone-NEON code path.
+
+## Open Questions
+
+1. **AVX-512 variant needed?** — The Metal backend only matters on macOS (Apple Silicon = no AVX). The AVX2 helper would only be exercised in cross-compilation tests or on Intel Macs (which Apple has discontinued). Probably not worth the extra code; this change defaults to building only the NEON variant and the scalar fallback. Reviewer may disagree.
+2. **Should the SIMD helper be exposed in the public C API?** — No, it's an internal helper for the dispatch layer. Static or `LWGEOM_INTERNAL` only.

--- a/openspec/changes/metal-simd-era-precompute/specs/simd-era-thetas/spec.md
+++ b/openspec/changes/metal-simd-era-precompute/specs/simd-era-thetas/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: SIMD-accelerated ERA thetas helper for GPU dispatch
+
+The system SHALL provide a SIMD-accelerated helper that computes pre-reduced Earth Rotation Angle (ERA) values for an array of points and writes them as `float` (32-bit) into a caller-provided output buffer. The helper SHALL be selected at runtime via the existing `LW_ACCEL_DISPATCH` table based on detected CPU features (NEON, AVX2, AVX-512, scalar fallback). The helper SHALL be the canonical way for any FP32_ONLY GPU backend (currently only Metal) to obtain pre-computed rotation angles without serializing the host-side ERA computation.
+
+The helper signature SHALL be:
+
+```c
+void lwgeom_accel_era_thetas(const double *data,
+                             size_t        stride_doubles,
+                             uint32_t      npoints,
+                             size_t        m_offset,
+                             int           direction,
+                             float        *thetas_out);
+```
+
+For each point index `i` in `[0, npoints)`, the helper SHALL:
+
+1. Read the M-epoch from `data[i * stride_doubles + m_offset]` as a `double`
+2. Compute the Julian Date in fp64: `jd = 2451545.0 + (epoch - 2000.0) * 365.25`
+3. Compute the Earth Rotation Angle in fp64 using the IERS 2010 linear approximation: `era = 2*PI * (0.7790572732640 + 1.00273781191135448 * (jd - 2451545.0))`
+4. Reduce ERA to `[0, 2*PI)` via `fmod` and wrap-if-negative, in fp64
+5. Apply the direction sign: `theta = direction * era`, in fp64
+6. Narrow to float ONCE: `thetas_out[i] = (float)theta`
+
+The fp64 stage of steps 2–5 SHALL be vectorized via SIMD intrinsics where available (NEON `float64x2_t` for ARM, AVX2 `__m256d` for x86-64 if AVX2 build is enabled). The narrowing in step 6 SHALL also be vectorized (`vcvt_f32_f64` for NEON, `_mm256_cvtpd_ps` for AVX2).
+
+#### Scenario: Helper is registered in the dispatch table
+
+- **WHEN** `lwaccel_init()` runs at process startup
+- **THEN** the global `LW_ACCEL_DISPATCH` struct returned by `lwaccel_get()` SHALL contain a non-NULL `era_thetas` function pointer
+- **AND** the function pointer SHALL be set to the NEON variant on ARM hosts where NEON is detected, the AVX2 variant on x86-64 hosts where AVX2 is detected (if compiled with AVX2 support), or the scalar fallback otherwise
+- **AND** the function pointer SHALL never be NULL after `lwaccel_init()` completes successfully
+
+#### Scenario: NEON helper is bit-equivalent to scalar reference (within fp64 rounding)
+
+- **GIVEN** an array of N points with M-epoch values in `data[i * stride + m_offset]` (fp64)
+- **WHEN** the NEON variant `lwgeom_accel_era_thetas_neon()` and the scalar reference `lwgeom_accel_era_thetas_scalar()` both process independent copies of the input
+- **THEN** the outputs SHALL be identical within fp64 rounding error (each output element matches to the last bit of float32 representation, because the only narrowing happens at the last step and both variants narrow the same fp64 value)
+- **AND** the maximum absolute difference between the two outputs SHALL be `0.0` (NOT a small epsilon, because both variants compute identical fp64 results before narrowing)
+
+#### Scenario: SIMD helper feeds Metal kernel without precision loss
+
+- **GIVEN** an input POINTARRAY with M-epoch column in fp64 (e.g., `bench_make_test_pa(500000)` which generates epochs in `[2025.0, 2026.0)`)
+- **WHEN** `lwgpu_metal_rotate_z_m_epoch()` calls `lwaccel_get()->era_thetas(...)` to populate the thetas buffer instead of using the scalar serial loop, then dispatches the Metal kernel
+- **THEN** the GPU output SHALL match the scalar reference `ptarray_rotate_z_m_epoch_scalar()` within `FP32_EARTH_SCALE_TOLERANCE` (~6.4 m for Earth-scale ECEF coordinates)
+- **AND** the precision contract SHALL be unchanged from PR #13 — this is a pure performance refactor, not a precision change
+
+#### Scenario: Direction parameter is applied per point inside the SIMD loop
+
+- **WHEN** `lwgeom_accel_era_thetas` is called with `direction = -1`
+- **THEN** every output element SHALL satisfy `thetas_out[i] = -fp64_reduced_era_at_point_i` (narrowed to float)
+- **WHEN** the same call is made with `direction = +1`
+- **THEN** every output element SHALL satisfy `thetas_out[i] = +fp64_reduced_era_at_point_i` (narrowed to float)
+- **AND** the helper SHALL NOT skip the multiplication when `direction = +1` (a separate code path would not be more efficient and would risk divergence between the two directions)
+
+#### Scenario: Output buffer is owned by caller
+
+- **WHEN** `lwgeom_accel_era_thetas` is called
+- **THEN** the helper SHALL NOT allocate or free `thetas_out`
+- **AND** the helper SHALL write exactly `npoints * sizeof(float)` bytes to `thetas_out`
+- **AND** the caller SHALL be responsible for ensuring `thetas_out` has at least that much space before the call
+
+### Requirement: Throughput target for SIMD ERA helper
+
+The NEON variant of `lwgeom_accel_era_thetas` SHALL achieve a throughput such that the combined `lwgpu_metal_rotate_z_m_epoch` end-to-end performance (host SIMD ERA precompute + GPU dispatch + GPU kernel) is at least 1.5× the standalone NEON `ptarray_rotate_z_m_epoch_neon` throughput at 500,000 points on Apple A18 Pro hardware.
+
+#### Scenario: Performance target met on A18 Pro
+
+- **GIVEN** the standalone `bench_metal` benchmark running on Apple A18 Pro at 500,000 points
+- **WHEN** the rotate_z_m_epoch operation runs through the Metal path with the SIMD ERA precompute helper enabled
+- **THEN** the measured throughput SHALL be at least `1.5 * 76 Mpts/s ≈ 114 Mpts/s` (target: ~130 Mpts/s)
+- **AND** if measured throughput is below `114 Mpts/s`, the change SHALL NOT be merged without an explicit waiver documenting why
+
+#### Scenario: Benchmark output breaks down host vs GPU phases
+
+- **WHEN** `bench_metal` runs the rotate_z_m_epoch benchmark with SIMD ERA precompute enabled
+- **THEN** the CSV output SHALL include two new columns: `host_era_us` (microseconds spent in `lwgeom_accel_era_thetas` for the SIMD precompute phase) and `gpu_kernel_us` (microseconds spent in the Metal kernel dispatch + execute phase)
+- **AND** the existing `total_us` column SHALL approximately equal `host_era_us + gpu_kernel_us + small_overhead`
+- **AND** the breakdown SHALL allow a reviewer to identify which phase is the bottleneck for any given workload size

--- a/openspec/changes/metal-simd-era-precompute/tasks.md
+++ b/openspec/changes/metal-simd-era-precompute/tasks.md
@@ -1,0 +1,48 @@
+## 1. SIMD ERA helper implementation
+
+- [ ] 1.1 Add `era_thetas` function pointer field to `struct LW_ACCEL_DISPATCH` in `liblwgeom/lwgeom_accel.h`
+- [ ] 1.2 Add scalar fallback `lwgeom_accel_era_thetas_scalar` in `liblwgeom/lwgeom_accel.c` next to the existing scalar dispatch entries; uses `lweci_epoch_to_jd` and `lweci_earth_rotation_angle` from `lwgeom_eci.c`
+- [ ] 1.3 Create new file `liblwgeom/accel/era_thetas_neon.c` containing `lwgeom_accel_era_thetas_neon`. Use `float64x2_t` for the fp64 epoch -> JD -> ERA -> mod-2*pi -> direction-sign pipeline, then `vcvt_f32_f64` to narrow each lane to float
+- [ ] 1.4 Reuse the existing NEON ERA constants from `rotate_z_neon.c` if accessible; otherwise duplicate them as static `const float64x2_t` in the new file
+- [ ] 1.5 Handle the trailing element for odd `npoints` by falling back to the scalar helper for the last point
+- [ ] 1.6 Wire the new helpers into `lwaccel_init()` in `lwgeom_accel.c`: NEON variant on `LW_ACCEL_NEON`, scalar fallback otherwise. Skip AVX2 for now (not needed on Apple Silicon target)
+
+## 2. Metal dispatch refactor
+
+- [ ] 2.1 In `liblwgeom/accel/gpu_metal.m`, in `lwgpu_metal_rotate_z_m_epoch()`, replace the inline serial loop that computes thetas with a single call to `lwaccel_get()->era_thetas(data, stride_doubles, n, m_off, dir, thetas)`
+- [ ] 2.2 Remove the now-unused inline helpers `metal_epoch_to_jd` and `metal_earth_rotation_angle` from `gpu_metal.m`
+- [ ] 2.3 Verify the dispatch table is initialized before this call site; the existing rotate_z_m_epoch_neon path depends on the same initialization order so it should be safe
+
+## 3. Tests
+
+- [ ] 3.1 Add `test_simd_era_thetas_scalar` in `liblwgeom/cunit/cu_metal.c` (or a new `cu_simd_era.c`) that calls the scalar helper directly with a known input and asserts each output element equals the expected float-narrowed scalar reference value
+- [ ] 3.2 Add `test_simd_era_thetas_neon` that does the same for the NEON variant, comparing element-by-element to the scalar variant (max diff SHALL be 0.0 because both narrow the same fp64 value)
+- [ ] 3.3 Add `test_metal_rotate_z_m_epoch_simd_era` that runs `lwgpu_metal_rotate_z_m_epoch` with the SIMD helper in the dispatch table and asserts the output matches the scalar reference within `FP32_EARTH_SCALE_TOLERANCE`
+- [ ] 3.4 Update the `metal_suite_setup()` call to register the new tests
+
+## 4. Benchmark instrumentation
+
+- [ ] 4.1 In `liblwgeom/bench/bench_metal.c`, add a new sub-benchmark or extend the existing rotate_z_m_epoch case to time the host ERA precompute and the GPU dispatch+execute as separate phases
+- [ ] 4.2 Use `now_us()` (already in the file) to capture timestamps before/after the `era_thetas` call and before/after the GPU dispatch -- may need a hook in `gpu_metal.m` to expose the phase boundary
+- [ ] 4.3 Add CSV columns `host_era_us` and `gpu_kernel_us` to the benchmark output
+- [ ] 4.4 Run on Apple A18 Pro at 100K, 500K, 1M points and capture results for the design.md update
+
+## 5. Verification
+
+- [ ] 5.1 Run `./cu_tester metal` and confirm all tests pass (existing 6 + new 3 = 9 tests)
+- [ ] 5.2 Run `./bench_metal` and confirm `rotate_z_m/metal` at 500K points achieves ≥114 Mpts/s (1.5x current NEON 76 Mpts/s)
+- [ ] 5.3 Run `./bench_metal --csv` and confirm the new `host_era_us` and `gpu_kernel_us` columns are populated
+- [ ] 5.4 Verify no regression in `rotate_z_m/scalar` and `rotate_z_m/neon` standalone benchmarks
+
+## 6. Documentation
+
+- [ ] 6.1 Update `apple-metal-gpu-backend/design.md` Risks/Trade-offs section: mark the "Host-side ERA precomputation serializes the hot path" entry as resolved with a one-line back-reference to this change and the new measured throughput
+- [ ] 6.2 Update `lwgeom_accel.c`'s `effective_gpu_threshold()` comment with the new measured Metal performance, but do NOT change the 5x multiplier in this commit
+- [ ] 6.3 Add a brief note in `liblwgeom/accel/gpu_metal.m`'s file header about the new dispatch path through `lwaccel_get()->era_thetas`
+
+## 7. Merge and archive
+
+- [ ] 7.1 Open PR from `metal-simd-era-precompute` implementation branch to fork develop
+- [ ] 7.2 Wait for CI green
+- [ ] 7.3 Merge to develop
+- [ ] 7.4 Archive this openspec change via `openspec archive metal-simd-era-precompute`

--- a/openspec/changes/multi-vendor-gpu-rollout/.openspec.yaml
+++ b/openspec/changes/multi-vendor-gpu-rollout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/multi-vendor-gpu-rollout/design.md
+++ b/openspec/changes/multi-vendor-gpu-rollout/design.md
@@ -1,0 +1,204 @@
+## Context
+
+PostGIS has GPU-acceleration source files for four backends (CUDA, ROCm, oneAPI, Metal) committed to develop, but only Metal has been validated end-to-end on real hardware. The user has access to Apple Silicon today and will get DGX Spark (NVIDIA Grace + Hopper, ARM) and an x86_64 + NVIDIA workstation in subsequent phases of personal hardware acquisition. AMD and Intel hardware access is planned but not yet scheduled.
+
+The challenge: keep the validation effort linear in the number of backends, not quadratic in the number of (backend × test-harness × hardware) combinations. Achieve this by building shared infrastructure once (Phase 0 — already mostly done via the gpu-precision-classes change) and applying the same per-phase validation template to each backend in turn.
+
+This roadmap is a living document. As phases complete, the corresponding entries get checked off and links are added to the focused implementation changes that did the work. The roadmap itself is never archived in the conventional OpenSpec sense — instead, it remains in `openspec/changes/` as the canonical "where are we" reference for the multi-vendor effort.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Maintain a single, reviewable, OpenSpec-tracked plan for validating all four GPU backends across the user's accessible (and future-accessible) hardware
+- Minimize duplicated effort across phases by identifying shared infrastructure (precision classes spec, dispatch table, test tolerances, benchmark harness, build-env Docker images)
+- Define per-phase success criteria so "phase complete" is unambiguous
+- Document the relationship between this roadmap and focused per-phase implementation OpenSpec changes
+- Make hardware dependencies explicit so future-self knows which phases are actionable today
+- Allow phases to be reordered, paused, or skipped without invalidating the roadmap
+
+**Non-Goals:**
+- Implementing any phase. This change is planning only.
+- Defining the exact API of any backend. The API is in `liblwgeom/lwgeom_gpu.h` already; this roadmap validates that API on each backend, not redesigns it.
+- Predicting calendar dates. Hardware acquisition is opportunistic; the roadmap orders phases by dependency, not by deadline.
+- Replacing the standard OpenSpec workflow. Each phase still gets its own focused OpenSpec change at implementation time. This roadmap is the parent document.
+
+## Decisions
+
+### Decision 1: Phases ordered by hardware access, then by dependency
+
+**Choice:** Phase order is:
+
+0. **Foundation** (no hardware needed) — `gpu-precision-classes` capability, `cu_accel_tolerances.h`, `lwgpu_backend_precision_class()` accessor. Already proposed in a sibling OpenSpec change.
+1. **Apple Metal** (Apple Silicon, available today) — `apple-metal-gpu-backend` change is at PR review (PR #13). Follow-up performance work in `metal-simd-era-precompute` (sibling change).
+2. **NVIDIA CUDA on ARM** (DGX Spark, expected next) — validates that the existing `gpu_cuda.cu` source compiles and runs on Grace + Hopper.
+3. **NVIDIA CUDA on x86_64** (later x86 workstation) — validates the same source on the more conventional x86 + discrete-GPU configuration.
+4. **AMD ROCm** (TBD AMD hardware) — validates `gpu_rocm.hip` on Instinct or Radeon Pro.
+5. **Intel oneAPI** (TBD Intel hardware) — validates `gpu_oneapi.cpp` on Arc or Data Center GPU.
+6. **Cross-vendor benchmark harness** (requires all of above) — produces apples-to-apples benchmarks across all four GPU backends + scalar/SIMD references.
+
+**Rationale:** Phases 2 and 3 are split because the user's hardware acquisition order is ARM-first. They could collapse into one change at implementation time. Phases 4 and 5 are independent; whichever vendor hardware lands first goes first. Phase 6 is the capstone that produces the data needed for the final upstream PR's "why this is worth it" pitch.
+
+**Alternatives considered:**
+- **(A) Phase order by vendor revenue / market share** (CUDA → ROCm → oneAPI → Metal). Rejected because hardware availability dominates: the user has Apple Silicon today and DGX Spark soon.
+- **(B) All-CUDA first** (validate ARM and x86 CUDA together). Considered for collapsing but kept split because the ARM CUDA combination has unique characteristics (Grace ↔ Hopper memory architecture, Linux-on-ARM toolchain quirks) that x86 builds don't see.
+- **(C) Skip x86 entirely** since most production deployments are x86. Rejected because PostGIS users do run on x86 + NVIDIA, and validating both ARM and x86 CUDA confirms the abstraction is genuinely portable, not accidentally ARM-tuned.
+
+### Decision 2: Per-phase template — what each focused change includes
+
+**Choice:** Every per-phase implementation OpenSpec change SHALL include:
+
+1. **Validation against the existing source** — confirm the backend's `gpu_<vendor>.{cu,m,cpp,hip}` and supporting files compile, link, and produce correct output. No source rewrites unless a real bug is found.
+2. **Precision class declaration** — assert via the `lwgpu_backend_precision_class()` accessor that the backend's class matches the gpu-precision-classes spec. For all backends except Metal this should be `FP64_NATIVE`.
+3. **CUnit test suite** — `cu_<vendor>.c` modeled after `cu_metal.c`, with init/rotate_z_uniform/rotate_z_m_epoch/rad_convert/fallback/small/large tests. Reuse the shared `cu_accel_tolerances.h` constants (`FP64_STRICT_TOLERANCE` for FP64_NATIVE backends).
+4. **Benchmark integration** — `bench_<vendor>` (or extension of `bench_accel`) that produces throughput numbers comparable to NEON and Metal.
+5. **Dispatch tuning** — measure crossover point vs NEON, set the per-backend threshold multiplier in `effective_gpu_threshold()`.
+6. **CI integration** — if a CI runner with the corresponding hardware exists, wire the backend into the matrix. If not, document the manual validation procedure.
+7. **Documentation update** — update the gpu-precision-classes spec (or its successor) with a checkmark in the "validated on real hardware" column for the backend.
+
+**Rationale:** Templating per-phase work means each focused change has a predictable shape. Reviewers know what to expect. Implementers know what's required. The template can be revised as we learn from each phase.
+
+**Alternatives considered:**
+- **(A) No template, each phase improvises** — risks each phase missing important validation steps.
+- **(B) Stricter template requiring CI integration on every phase** — rejected because the user's hardware access is opportunistic and CI runners with vendor-specific GPUs are expensive. Manual validation procedure is acceptable when CI isn't possible.
+
+### Decision 3: This roadmap change is never archived
+
+**Choice:** `multi-vendor-gpu-rollout` stays in `openspec/changes/` indefinitely. Phases get checked off in `tasks.md` as they complete, and links to the focused implementation changes are added inline. The change itself does not graduate to `openspec/specs/` via `openspec archive`.
+
+**Rationale:** OpenSpec's archive workflow is designed for changes that propose a discrete delta to the spec and then become part of the spec when the delta lands. A roadmap is different: it's a living plan that tracks ongoing work. Archiving it would lose the "where are we" function.
+
+The risk is OpenSpec validators may eventually flag this as a stale change. We accept that risk and document the convention here so future maintainers don't try to "clean up" the roadmap by archiving it.
+
+**Alternatives considered:**
+- **(A) Archive the roadmap and create a new one each year** — loses continuity and creates archive sprawl.
+- **(B) Keep the roadmap as a markdown file outside OpenSpec** — loses the validation, structure, and reviewability that OpenSpec provides. The user explicitly preferred OpenSpec for planning.
+- **(C) Archive after each phase and create a new roadmap for the remainder** — too much overhead.
+
+### Decision 4: Phase prerequisites are documented but not enforced
+
+**Choice:** Each phase's `tasks.md` entry lists its prerequisites (e.g., Phase 2 depends on the user having SSH access to a DGX Spark). If a prerequisite is not met, the phase simply remains unchecked in the tracking table — there is no automated gate.
+
+**Rationale:** The user is the only consumer of this roadmap right now. Self-discipline plus written prerequisites is sufficient. Automation would add complexity for no benefit.
+
+## Phase details
+
+### Phase 0: Foundation (precision classes, shared tolerances, accessor)
+
+**Status**: Specified in sibling OpenSpec change `gpu-backend-precision-classes`. Implementation pending after the change is committed.
+
+**Prerequisites**: None.
+
+**Success criteria**:
+- `openspec/specs/gpu-precision-classes/spec.md` exists (after the precision-classes change archives)
+- `liblwgeom/cunit/cu_accel_tolerances.h` exists with `FP32_EARTH_SCALE_TOLERANCE` and `FP64_STRICT_TOLERANCE`
+- `lwgpu_backend_precision_class(LW_GPU_BACKEND b)` accessor is in `lwgeom_gpu.h` and returns the correct class for every existing enum value
+- `cu_metal.c` uses the shared header (no local `#define`)
+- Build green, all existing tests pass
+
+**Unblocks**: All subsequent phases. Without the precision class accessor and shared tolerances, every per-phase change would have to re-derive them.
+
+### Phase 1: Apple Metal validation + perf
+
+**Status**: PR #13 in flight on user's fork (`apple-metal-gpu-backend`). Performance follow-up planned in sibling change `metal-simd-era-precompute`.
+
+**Prerequisites**: Apple Silicon hardware (user has A18 Pro and M-series Macs). Xcode Command Line Tools.
+
+**Success criteria** (Phase 1a — already met by PR #13):
+- `cu_tester metal` runs 6/6 tests passing on A18 Pro
+- Metal kernels produce output within `FP32_EARTH_SCALE_TOLERANCE` of scalar reference
+- The OpenSpec change `apple-metal-gpu-backend` is internally consistent (no float-vs-double contradictions)
+
+**Success criteria** (Phase 1b — pending the metal-simd-era-precompute change):
+- `bench_metal` shows `rotate_z_m/metal` ≥ 1.5× NEON throughput at 500K points on A18 Pro
+- The perf regression from the precision fix (currently ~8% below NEON) is closed
+
+**Unblocks**: Confidence in the shared GPU abstraction layer's ability to host a real backend end-to-end. This is the first proof that the Metal-specific work was correctly factored to be reusable.
+
+### Phase 2: NVIDIA CUDA on ARM (DGX Spark)
+
+**Status**: Not started. Hardware not yet acquired.
+
+**Prerequisites**:
+- DGX Spark hardware with SSH access (or equivalent ARM + NVIDIA Grace + Hopper system)
+- CUDA Toolkit 12+ for ARM Linux
+- Phase 0 complete
+
+**Success criteria**:
+- Existing `liblwgeom/accel/gpu_cuda.cu` compiles cleanly via `nvcc` on the target
+- `lwgpu_cuda_init()` succeeds on the device
+- New `cu_cuda.c` test suite runs all rotate_z and rad_convert tests with `FP64_STRICT_TOLERANCE` (`1e-10` absolute, NOT scale-relative — CUDA is FP64_NATIVE)
+- CUDA output matches scalar reference within `FP64_STRICT_TOLERANCE`
+- `bench_cuda` (or extension of bench_accel) produces throughput numbers
+- `lwgpu_backend_precision_class(LW_GPU_CUDA) == LW_GPU_PRECISION_FP64_NATIVE` confirmed via test assertion
+- A spawned focused OpenSpec change `cuda-gpu-validation-on-arm` is created, all 4 artifacts complete and validated, and merged to develop
+
+**Unblocks**: Phase 3 (CUDA on x86 — most of the work is shared; only the toolchain and host CPU changes). Also unblocks the cross-vendor benchmark harness (Phase 6).
+
+### Phase 3: NVIDIA CUDA on x86_64
+
+**Status**: Not started. Hardware not yet acquired.
+
+**Prerequisites**:
+- x86_64 Linux workstation with NVIDIA discrete GPU (RTX, A-series, or similar)
+- CUDA Toolkit 12+
+- Phase 2 complete (so the source has been validated; this phase just confirms portability)
+
+**Success criteria**: Same as Phase 2 but on x86 + discrete NVIDIA. The focused change `cuda-gpu-validation-on-x86` may be a small diff against the Phase 2 change if everything just works, OR a more substantial change if x86-specific issues arise.
+
+**Unblocks**: Confidence that the CUDA backend is portable across host architectures. Most production NVIDIA deployments are x86; this is the validation that matters for upstream PostGIS adoption.
+
+### Phase 4: AMD ROCm/HIP
+
+**Status**: Not started. Hardware not yet acquired.
+
+**Prerequisites**:
+- AMD GPU with ROCm support (Instinct MI series, Radeon Pro VII / W6800+, or Radeon RX 7000 series)
+- ROCm 6+ installed
+- Phase 0 complete
+
+**Success criteria**: Same template as Phases 2/3 but for `liblwgeom/accel/gpu_rocm.hip` and `LW_GPU_ROCM`. Spawn focused change `rocm-gpu-validation`.
+
+**Unblocks**: Confidence the abstraction layer works on a third vendor. After this phase, the precision-class model has been verified against three FP64_NATIVE backends, all behaving identically.
+
+### Phase 5: Intel oneAPI/SYCL
+
+**Status**: Not started. Hardware not yet acquired.
+
+**Prerequisites**:
+- Intel GPU with oneAPI support (Arc, Data Center GPU Max, or Iris Xe with caveats)
+- oneAPI Base Toolkit 2024+
+- Phase 0 complete
+
+**Success criteria**: Same template, for `liblwgeom/accel/gpu_oneapi.cpp` and `LW_GPU_ONEAPI`. Spawn focused change `oneapi-gpu-validation`.
+
+**Caveat**: Some Intel iGPUs do NOT have fp64 hardware (consumer Iris Xe before Arc). If the only available test hardware is one of those, the precision class for oneAPI would have to be FP32_ONLY for THAT specific configuration — but the spec models the BACKEND class, not the device class. This may require a follow-up amendment to gpu-precision-classes if it becomes a real concern.
+
+**Unblocks**: Confidence the abstraction layer works on all four major GPU vendors.
+
+### Phase 6: Cross-vendor benchmark harness
+
+**Status**: Not started. Requires all four backends validated.
+
+**Prerequisites**: Phases 1, 2 (or 3), 4, 5 all complete.
+
+**Success criteria**:
+- A single benchmark harness that, given access to multiple backends, produces apples-to-apples throughput numbers across CUDA, ROCm, oneAPI, Metal, NEON, AVX, and scalar
+- A summary table in `openspec/specs/gpu-precision-classes/spec.md` (or its successor) showing measured throughput per backend per operation per point count
+- The data needed to write the upstream PostGIS PR's "why this is worth it" section
+
+**Unblocks**: Upstream PR. With validated cross-vendor data, the upstream pitch is "PostGIS now has GPU acceleration on every major vendor with a reviewable precision contract" rather than "we have CUDA code that may or may not work".
+
+## Risks / Trade-offs
+
+- **[Risk] Hardware acquisition timeline is unpredictable** → mitigation: phase order is robust to delays. Phases 2-5 are independent; whichever hardware arrives first goes first.
+- **[Risk] One backend has a fundamental issue that blocks the rollout** → mitigation: each phase is independent. A blocker on (say) ROCm doesn't stop CUDA or Metal validation. The roadmap explicitly does not require all phases to complete in order.
+- **[Risk] Maintainer of the upstream PostGIS project rejects the multi-backend contribution as too large** → mitigation: structure the upstream PR(s) by backend, with the precision-classes spec landing first as a foundation, then each backend as its own PR. If upstream wants to take only a subset, they can.
+- **[Trade-off] Living roadmap that never archives** → unconventional for OpenSpec. Documented in Decision 3 above. Convention may need revisiting if it causes confusion.
+- **[Trade-off] Per-phase changes don't exist yet** → only the roadmap is created in this commit. Empty placeholder changes for future phases would create stale artifacts. Better to spawn focused changes when the work actually starts.
+
+## Open Questions
+
+1. **Should there be a Phase 7 for performance comparison vs CPU baselines on real GIS workloads** (not synthetic benchmarks)? — Could be valuable but requires real-world dataset access. Defer until cross-vendor harness exists.
+2. **What about compute-shader-based backends like Vulkan or WebGPU?** — Out of scope. Re-evaluate if a vendor-neutral compute story matures.
+3. **Should the precision-classes spec be promoted to a top-level PostGIS concept** (not just GPU)? — E.g., a future fp16 SIMD batch path would benefit from the same classification. Defer until that materializes.
+4. **Does the upstream PostGIS project want this work at all?** — Unknown. Reach out to the postgis-devel list when Phase 1 (Metal) lands and use the discussion to shape Phases 2-5 priority.

--- a/openspec/changes/multi-vendor-gpu-rollout/proposal.md
+++ b/openspec/changes/multi-vendor-gpu-rollout/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+PostGIS has GPU-acceleration *infrastructure* in place (`liblwgeom/lwgeom_gpu.h`, `liblwgeom/accel/gpu_*.{cu,m,cpp,hip,metal}`, and the `LW_GPU_BACKEND` enum with five values: NONE / CUDA / ROCM / ONEAPI / METAL) but only one backend has been **validated end-to-end on real hardware**: Apple Metal, via PR #13. The other three backends (CUDA, ROCm, oneAPI) exist as source files committed to develop but have not been built, tested, or benchmarked on the corresponding vendor hardware. They are **unvalidated** in the literal sense — no human has confirmed they compile, link, dispatch, or produce correct output.
+
+This change captures the strategic rollout plan to validate all four GPU backends across the hardware the user has access to (or will have access to), in a phased order that maximizes early signal and minimizes wasted effort. It is **not** itself an implementation change. It is a planning artifact that:
+
+1. Enumerates the phases in concrete order with hardware dependencies, success criteria, and what gets unblocked when each phase completes
+2. Identifies what is shared infrastructure across phases (so it gets built once, not five times)
+3. Identifies what is phase-specific (so each phase has a clean, focused OpenSpec change)
+4. Documents the user's access to hardware so future-self knows which phase is actionable today
+5. Provides a tracking checklist for which phases have completed, are in flight, or are waiting on hardware availability
+
+When each phase becomes actionable (hardware available, prerequisites met), a separate focused OpenSpec change SHOULD be created from the corresponding task in this roadmap. This change itself never gets archived in the normal sense — it stays in `openspec/changes/` as the living roadmap, with task checkboxes ticked off as phases complete and links added to the focused changes that implement them.
+
+## What Changes
+
+This change creates a single new "capability" that captures the rollout plan as a structured document. It does not modify any code, configure any backend, or change any test. It exists purely to make the strategic plan **reviewable as a spec** rather than as a side-channel document.
+
+- Create a new capability `multi-vendor-gpu-rollout` that captures: phase order, per-phase prerequisites, per-phase success criteria, shared infrastructure, hardware dependencies, and a tracking table
+- Document the relationship between this roadmap and the focused per-phase OpenSpec changes that will be spawned from it
+- Establish the convention: this change is **not archived** when phases complete. Instead, individual phases get checked off in `tasks.md` and links to the implementing changes are added. This is unusual for OpenSpec but appropriate for a long-running plan.
+
+## Capabilities
+
+### New Capabilities
+
+- `multi-vendor-gpu-rollout`: A living roadmap capability that defines the phased plan for validating PostGIS GPU backends across vendor hardware (Apple Metal, NVIDIA CUDA on ARM, NVIDIA CUDA on x86, AMD ROCm, Intel oneAPI). Specifies phase order, prerequisites, success criteria, hardware dependencies, and the relationship between this roadmap and focused per-phase OpenSpec changes.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Code**: zero. No source files touched.
+- **Build system**: zero. No Makefiles or configure changes.
+- **Tests**: zero. No new test files.
+- **OpenSpec**: this change creates a new capability spec at archive time. The change itself stays in `openspec/changes/multi-vendor-gpu-rollout/` indefinitely as a living document.
+- **Process**: establishes the convention that strategic roadmaps live as OpenSpec changes (not as side-channel docs), and that focused per-phase changes are spawned from the roadmap as hardware becomes available.
+
+## Phases at a glance
+
+| Phase | Backend           | Hardware                    | Status (2026-04-11)                                          |
+|-------|-------------------|-----------------------------|--------------------------------------------------------------|
+| 0     | Foundation        | n/a                         | **Done** — gpu-precision-classes (sibling change), liblwgeom/lwgeom_gpu.h abstraction layer, dispatch table |
+| 1     | Apple Metal       | Apple Silicon (M-series, A18 Pro) | **Mostly done** — PR #13 (apple-metal-gpu-backend) merged-pending. Follow-up performance work in metal-simd-era-precompute (sibling change) |
+| 2     | NVIDIA CUDA (ARM) | DGX Spark (Grace + Hopper)  | **Waiting on hardware access** (user has DGX Spark planned)   |
+| 3     | NVIDIA CUDA (x86) | x86_64 Linux + RTX/A-series | **Waiting on hardware access**                                |
+| 4     | AMD ROCm/HIP      | AMD Instinct or Radeon Pro  | **Waiting on hardware access**                                |
+| 5     | Intel oneAPI      | Intel Arc / Data Center GPU | **Waiting on hardware access**                                |
+| 6     | Cross-vendor benchmark harness | All of the above | **Waiting on phases 2-5 to complete**                         |
+
+See `design.md` for per-phase details and `tasks.md` for the tracking checklist.
+
+## Open Questions
+
+1. **Should each phase get its own OpenSpec change as soon as hardware is available, or only when implementation actually starts?** — Recommendation: only when implementation starts. Pre-creating empty changes for unstarted phases creates stale artifacts that decay. The roadmap captures the plan; focused changes capture the work.
+2. **Should phases 2 and 3 be merged into a single "CUDA validation" phase?** — Considered. They share the same source files (`gpu_cuda.cu`) and the validation goal is the same. Splitting into ARM vs x86 makes sense because (a) the user's hardware acquisition order is ARM first, x86 later, and (b) ARM CUDA exposes Grace CPU + Hopper GPU asymmetries that x86 builds don't see. Keep them split for now; they can collapse into one focused change at implementation time if it makes sense.
+3. **Where does PG-Strom fit?** — Out of scope. PG-Strom is a separate query-level GPU offload project that uses CUDA for whole-query acceleration. PostGIS's GPU abstraction is for batch coordinate transforms, a much narrower scope. The two could coexist but are not in the rollout plan.
+4. **Should the roadmap include WebGPU as a future portable backend?** — Out of scope. WebGPU compute support is still maturing and the precision/performance characteristics on each browser+OS combination are too unstable to plan against. Re-evaluate in 1-2 years.
+5. **What about non-GPU accelerators (TPU, NPU, VPU)?** — Out of scope. The dispatch abstraction could in principle support them, but no current PostGIS workload would benefit and the testing burden is enormous. Document as a deferred consideration.

--- a/openspec/changes/multi-vendor-gpu-rollout/specs/multi-vendor-gpu-rollout/spec.md
+++ b/openspec/changes/multi-vendor-gpu-rollout/specs/multi-vendor-gpu-rollout/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Living roadmap for multi-vendor GPU validation
+
+The PostGIS fork SHALL maintain a single, OpenSpec-tracked, living roadmap document that captures the phased plan for validating GPU backends (Apple Metal, NVIDIA CUDA, AMD ROCm, Intel oneAPI) across vendor hardware. The roadmap SHALL be reviewable as a spec, SHALL document phase order with hardware dependencies, and SHALL serve as the canonical "where are we" reference for the multi-vendor effort.
+
+The roadmap SHALL NOT be archived in the conventional OpenSpec sense when individual phases complete. Instead, it SHALL remain in `openspec/changes/multi-vendor-gpu-rollout/` indefinitely, with phases tracked via checkboxes and links to focused per-phase implementation OpenSpec changes added inline as those changes are spawned.
+
+#### Scenario: Roadmap exists and is discoverable
+
+- **WHEN** a maintainer wants to find the multi-vendor GPU rollout plan
+- **THEN** they SHALL find it at `openspec/changes/multi-vendor-gpu-rollout/` with the standard OpenSpec artifact set (proposal.md, design.md, specs/, tasks.md)
+- **AND** the proposal.md SHALL contain the at-a-glance phase table
+- **AND** the design.md SHALL contain per-phase details, prerequisites, success criteria, and the rationale for phase ordering
+
+#### Scenario: Phases are checked off as they complete
+
+- **WHEN** a phase's success criteria are met (per design.md per-phase definitions)
+- **THEN** the corresponding entry in `tasks.md` SHALL have its checkbox ticked
+- **AND** a link to the focused implementation OpenSpec change that completed the phase SHALL be added inline next to the checked item
+- **AND** the at-a-glance phase table in proposal.md SHALL be updated with the new status
+
+#### Scenario: New phases SHALL spawn focused OpenSpec changes
+
+- **WHEN** a phase becomes actionable (its prerequisites are met, hardware is available)
+- **THEN** a separate focused OpenSpec change SHALL be created using the per-phase template defined in design.md Decision 2
+- **AND** the focused change SHALL reference this roadmap in its proposal.md
+- **AND** the focused change SHALL follow the standard OpenSpec lifecycle (propose → review → implement → archive)
+- **AND** the roadmap SHALL be updated to link to the focused change
+
+### Requirement: Per-phase template for focused implementation changes
+
+Every focused OpenSpec change spawned from this roadmap to validate a specific GPU backend SHALL include the following elements, in addition to the standard OpenSpec artifact set.
+
+#### Scenario: Focused change includes validation of existing source
+
+- **WHEN** a focused per-phase change is created
+- **THEN** the proposal SHALL state that the change validates the existing `liblwgeom/accel/gpu_<vendor>.{cu,m,cpp,hip}` source compiles, links, and produces correct output on the target hardware
+- **AND** the proposal SHALL NOT propose source rewrites unless a real bug is found and documented
+
+#### Scenario: Focused change asserts precision class via accessor
+
+- **WHEN** a focused per-phase change implements its CUnit test suite
+- **THEN** at least one test SHALL assert `lwgpu_backend_precision_class(LW_GPU_<VENDOR>) == LW_GPU_PRECISION_<EXPECTED_CLASS>` where the expected class matches the gpu-precision-classes spec
+- **AND** for all current GPU backends except Metal, the expected class SHALL be `LW_GPU_PRECISION_FP64_NATIVE`
+
+#### Scenario: Focused change uses shared tolerance constants
+
+- **WHEN** a focused per-phase change writes its CUnit tests
+- **THEN** the test files SHALL `#include "cu_accel_tolerances.h"` and use the appropriate constant for the backend's precision class
+- **AND** FP64_NATIVE backends SHALL use `FP64_STRICT_TOLERANCE` (`1e-10`)
+- **AND** FP32_ONLY backends SHALL use `FP32_EARTH_SCALE_TOLERANCE` (~6.4 m for Earth-scale ECEF)
+- **AND** the focused change SHALL NOT define its own local tolerance `#define`s
+
+#### Scenario: Focused change includes benchmark integration
+
+- **WHEN** a focused per-phase change is implemented
+- **THEN** it SHALL produce throughput numbers comparable to the existing NEON and Metal benchmarks
+- **AND** the comparison SHALL be at the same point counts (1K, 10K, 50K, 100K, 500K) as `bench_metal` for direct comparison
+- **AND** the throughput data SHALL be added to the per-phase entry in this roadmap's design.md once measured
+
+#### Scenario: Focused change documents dispatch tuning
+
+- **WHEN** a focused per-phase change measures performance
+- **THEN** it SHALL determine the crossover point where the GPU backend beats the CPU SIMD baseline
+- **AND** it SHALL set or recommend a per-backend threshold multiplier in `effective_gpu_threshold()` (similar to Metal's 5x multiplier)
+- **AND** the measurement methodology SHALL match the metal-simd-era-precompute change's benchmark instrumentation pattern
+
+### Requirement: Hardware availability tracking
+
+The roadmap SHALL include a tracking table that lists each phase's hardware prerequisites and current availability status. The table SHALL be updated as hardware is acquired so future maintainers know which phases are actionable today.
+
+#### Scenario: Hardware status table exists
+
+- **WHEN** a maintainer wants to know which phases can be started today
+- **THEN** they SHALL find a table in `proposal.md` (or `design.md`) listing each phase, its hardware requirement, and its current status (e.g., "available", "expected Q3", "not yet planned")
+- **AND** the status SHALL be updated whenever hardware acquisition or loss occurs
+
+#### Scenario: Status uses unambiguous terms
+
+- **WHEN** a phase's status is recorded in the tracking table
+- **THEN** it SHALL use one of: `Done`, `In progress`, `Mostly done`, `Available (not started)`, `Waiting on hardware access`, `Blocked`, `Deferred`
+- **AND** any status containing "Blocked" SHALL be accompanied by a brief explanation
+
+### Requirement: Roadmap supersedes ad-hoc planning documents
+
+The system SHALL NOT have parallel roadmap or planning documents for the multi-vendor GPU rollout effort outside of OpenSpec. Markdown files in `docs/`, README sections, or notes in code comments SHALL NOT duplicate or contradict the roadmap captured in this OpenSpec change.
+
+#### Scenario: Single source of truth
+
+- **WHEN** any code comment, README, or other documentation references the multi-vendor GPU rollout plan
+- **THEN** it SHALL link to `openspec/changes/multi-vendor-gpu-rollout/` rather than restate the plan
+- **AND** if a piece of information about the plan needs to live in a non-OpenSpec location (e.g., a CLAUDE.md file for AI assistants), it SHALL include a "see openspec/changes/multi-vendor-gpu-rollout/ for the authoritative version" pointer

--- a/openspec/changes/multi-vendor-gpu-rollout/tasks.md
+++ b/openspec/changes/multi-vendor-gpu-rollout/tasks.md
@@ -1,0 +1,136 @@
+## Phase tracking checklist
+
+This is a **living checklist**. Items get checked off as phases complete. Links to focused implementation OpenSpec changes are added inline as those changes are spawned. This change does NOT itself archive when items complete.
+
+## Phase 0: Foundation
+
+- [ ] 0.1 OpenSpec change `gpu-backend-precision-classes` proposed (sibling of this change)
+- [ ] 0.2 OpenSpec change `gpu-backend-precision-classes` approved and merged
+- [ ] 0.3 Implementation: `LW_GPU_PRECISION_CLASS` enum and `lwgpu_backend_precision_class()` accessor in `liblwgeom/lwgeom_gpu.h`
+- [ ] 0.4 Implementation: `liblwgeom/cunit/cu_accel_tolerances.h` with `FP32_EARTH_SCALE_TOLERANCE` and `FP64_STRICT_TOLERANCE`
+- [ ] 0.5 Implementation: `cu_metal.c` updated to use shared header
+- [ ] 0.6 Implementation: capability spec at `openspec/specs/gpu-precision-classes/spec.md` after archive
+- [ ] 0.7 Verification: `cu_tester metal` still passes 6/6 with the shared header
+
+## Phase 1: Apple Metal
+
+### 1a. Initial validation (PR #13)
+
+- [x] 1a.1 OpenSpec change `apple-metal-gpu-backend` proposed
+- [ ] 1a.2 PR #13 (`rebase/apple-metal-gpu-backend-2026-04-10` → `develop`) merged on fork
+- [x] 1a.3 `cu_tester metal` passes 6/6 on Apple A18 Pro
+- [x] 1a.4 Metal output within `FP32_EARTH_SCALE_TOLERANCE` of scalar reference
+- [x] 1a.5 OpenSpec change internally consistent (no double/float contradictions)
+
+### 1b. Performance follow-up (`metal-simd-era-precompute` sibling change)
+
+- [ ] 1b.1 OpenSpec change `metal-simd-era-precompute` proposed (sibling of this change, this batch)
+- [ ] 1b.2 OpenSpec change `metal-simd-era-precompute` approved and merged
+- [ ] 1b.3 Implementation: `lwgeom_accel_era_thetas_neon` helper in `liblwgeom/accel/era_thetas_neon.c`
+- [ ] 1b.4 Implementation: `gpu_metal.m` refactored to use the helper
+- [ ] 1b.5 Verification: `bench_metal` rotate_z_m/metal at 500K points ≥ 114 Mpts/s (1.5x NEON 76 Mpts/s)
+- [ ] 1b.6 Update `apple-metal-gpu-backend/design.md` Risks section to mark perf trade-off as resolved
+
+## Phase 2: NVIDIA CUDA on ARM (DGX Spark)
+
+**Hardware status (2026-04-11)**: Waiting on user hardware acquisition.
+
+**Prerequisites**:
+- DGX Spark or equivalent Grace + Hopper system with SSH access
+- CUDA Toolkit 12+ for ARM Linux
+- Phase 0 complete
+
+- [ ] 2.1 Hardware acquired and verified accessible
+- [ ] 2.2 OpenSpec change `cuda-gpu-validation-on-arm` spawned from this roadmap
+- [ ] 2.3 OpenSpec change has all 4 artifacts (proposal, design, specs, tasks) and validates
+- [ ] 2.4 Implementation: existing `gpu_cuda.cu` builds via `nvcc` on the target
+- [ ] 2.5 Implementation: `cu_cuda.c` test suite created (modeled after `cu_metal.c`, using `FP64_STRICT_TOLERANCE`)
+- [ ] 2.6 Implementation: `cu_tester cuda` passes all tests on DGX Spark
+- [ ] 2.7 Implementation: `lwgpu_backend_precision_class(LW_GPU_CUDA)` returns `FP64_NATIVE` (asserted in test)
+- [ ] 2.8 Implementation: `bench_cuda` (or extension of bench_accel) produces throughput numbers
+- [ ] 2.9 Implementation: dispatch threshold tuned for Grace + Hopper (likely lower than current 50K)
+- [ ] 2.10 Verification: throughput beats NEON at the new threshold by ≥ 1.5x
+- [ ] 2.11 OpenSpec change merged
+- [ ] 2.12 OpenSpec change archived
+
+## Phase 3: NVIDIA CUDA on x86_64
+
+**Hardware status (2026-04-11)**: Waiting on user hardware acquisition.
+
+**Prerequisites**:
+- x86_64 Linux workstation with NVIDIA discrete GPU
+- CUDA Toolkit 12+
+- Phase 2 complete (so the source has been validated; this phase confirms portability)
+
+- [ ] 3.1 Hardware acquired and verified accessible
+- [ ] 3.2 OpenSpec change `cuda-gpu-validation-on-x86` spawned from this roadmap
+- [ ] 3.3 If Phase 2 changes apply unmodified, this change may be small (just CI integration). If x86-specific issues arise, larger.
+- [ ] 3.4 `cu_tester cuda` passes on the x86 target
+- [ ] 3.5 `bench_cuda` produces x86 throughput numbers for comparison with ARM CUDA
+- [ ] 3.6 OpenSpec change merged and archived
+
+## Phase 4: AMD ROCm/HIP
+
+**Hardware status (2026-04-11)**: Waiting on user hardware acquisition.
+
+**Prerequisites**:
+- AMD GPU with ROCm support (Instinct, Radeon Pro, Radeon RX 7000)
+- ROCm 6+ installed
+- Phase 0 complete
+
+- [ ] 4.1 Hardware acquired and verified accessible
+- [ ] 4.2 OpenSpec change `rocm-gpu-validation` spawned from this roadmap
+- [ ] 4.3 Existing `gpu_rocm.hip` builds via `hipcc` on the target
+- [ ] 4.4 `cu_rocm.c` test suite created (modeled after `cu_metal.c`/`cu_cuda.c`, using `FP64_STRICT_TOLERANCE`)
+- [ ] 4.5 `cu_tester rocm` passes all tests
+- [ ] 4.6 `lwgpu_backend_precision_class(LW_GPU_ROCM)` returns `FP64_NATIVE` (asserted)
+- [ ] 4.7 `bench_rocm` produces throughput numbers
+- [ ] 4.8 Dispatch threshold tuned
+- [ ] 4.9 OpenSpec change merged and archived
+
+## Phase 5: Intel oneAPI/SYCL
+
+**Hardware status (2026-04-11)**: Waiting on user hardware acquisition.
+
+**Prerequisites**:
+- Intel GPU with oneAPI support (Arc, Data Center GPU Max, fp64-capable Iris Xe)
+- oneAPI Base Toolkit 2024+
+- Phase 0 complete
+
+- [ ] 5.1 Hardware acquired and verified accessible
+- [ ] 5.2 Verify the available Intel hardware actually supports fp64 compute (not all consumer iGPUs do). If not, escalate to spec authors as a "do we need a third precision class?" question
+- [ ] 5.3 OpenSpec change `oneapi-gpu-validation` spawned from this roadmap
+- [ ] 5.4 Existing `gpu_oneapi.cpp` builds via `icpx` on the target
+- [ ] 5.5 `cu_oneapi.c` test suite created
+- [ ] 5.6 `cu_tester oneapi` passes
+- [ ] 5.7 `lwgpu_backend_precision_class(LW_GPU_ONEAPI)` returns `FP64_NATIVE` (asserted) — assuming the target hardware has fp64
+- [ ] 5.8 `bench_oneapi` produces throughput numbers
+- [ ] 5.9 OpenSpec change merged and archived
+
+## Phase 6: Cross-vendor benchmark harness
+
+**Status**: Waiting on phases 1b, 2 (or 3), 4, 5 to all be complete.
+
+- [ ] 6.1 OpenSpec change `cross-vendor-benchmark-harness` spawned from this roadmap once at least three of {Metal, CUDA, ROCm, oneAPI} have been validated
+- [ ] 6.2 Single benchmark harness that runs all available backends on the same input data and produces apples-to-apples throughput numbers
+- [ ] 6.3 Summary table added to `openspec/specs/gpu-precision-classes/spec.md` (or its successor) with measured throughput per backend per operation per point count
+- [ ] 6.4 Data captured for the eventual upstream PostGIS PR's "why this is worth it" pitch
+- [ ] 6.5 OpenSpec change merged and archived
+
+## Phase 7: Upstream contribution to postgis/postgis
+
+**Status**: Waiting on Phase 6 (need cross-vendor data to write a compelling upstream pitch).
+
+- [ ] 7.1 Reach out to postgis-devel mailing list with summary and benchmark data
+- [ ] 7.2 Discuss preferred PR structure (one big PR vs phased PRs by backend)
+- [ ] 7.3 Spawn OpenSpec change `upstream-postgis-gpu-contribution` capturing the agreed structure and review process
+- [ ] 7.4 Submit upstream PR(s) following the agreed structure
+- [ ] 7.5 Iterate based on upstream review feedback
+- [ ] 7.6 Land at least the precision-classes capability and one backend (likely Metal or CUDA) upstream
+
+## Living document maintenance
+
+- [ ] L.1 Update the at-a-glance status table in `proposal.md` whenever a phase status changes
+- [ ] L.2 Add inline links from this checklist to spawned focused OpenSpec changes as they are created
+- [ ] L.3 Review the roadmap quarterly to update hardware status and re-prioritize as needed
+- [ ] L.4 If the OpenSpec validator ever flags this change as stale or requiring archive, point at design.md Decision 3 explaining why this change is intentionally never archived


### PR DESCRIPTION
## Summary

Three OpenSpec planning changes that capture the next phase of GPU acceleration work after PR #13 (Apple Metal backend) lands. All three are documentation only — no source code changes — and serve as the structured plan for ongoing multi-vendor GPU work that the user explicitly wants tracked in OpenSpec rather than side-channel docs.

## Why now

PR #13 fixed a real precision bug in the Metal backend and introduced a useful concept (the FP64_NATIVE / FP32_ONLY precision class model) that needs to graduate from a Metal-specific spec to a top-level capability before the next four backends (CUDA on ARM, CUDA on x86, ROCm, oneAPI) get validated. Rather than improvise the next set of changes ad-hoc, this PR captures the plan as three reviewable OpenSpec changes:

1. **`metal-simd-era-precompute`** (focused, immediate follow-up to PR #13)
2. **`gpu-backend-precision-classes`** (cross-cutting infrastructure that everything else builds on)
3. **`multi-vendor-gpu-rollout`** (living strategic roadmap; never archived)

## Change 1: `metal-simd-era-precompute`

The Metal `rotate_z_m_epoch` operation regressed from a (false) ~190 Mpts/s at 500K points to a real ~70 Mpts/s after PR #13's correctness fix moved ERA computation from the GPU kernel to a serial fp64 host loop. The fix is to parallelize the host-side ERA precompute using NEON intrinsics, restoring Metal as a clear ~1.7× win over NEON.

**Scope**: new `lwgeom_accel_era_thetas_neon()` helper, dispatch table integration, refactor of `lwgpu_metal_rotate_z_m_epoch()` to use the helper, new CUnit test, benchmark instrumentation. Estimated 1-2 days of implementation work.

**Capabilities**: new `simd-era-thetas` capability with two requirements (helper signature + throughput target).

## Change 2: `gpu-backend-precision-classes`

Extracts the FP64_NATIVE / FP32_ONLY precision class concept from the Metal-specific spec into its own top-level capability. Adds a compile-time accessor `lwgpu_backend_precision_class(LW_GPU_BACKEND b)` so future tests can assert classification at runtime, and a shared `cu_accel_tolerances.h` header so future test files don't have to define their own scale-relative tolerances.

**Scope**: new enum + accessor in `lwgeom_gpu.h`, new shared header in `liblwgeom/cunit/`, light updates to the Metal spec to reference the new top-level capability instead of duplicating the model. **Zero behavior changes** — pure documentation refactor + tiny accessor.

**Why it matters**: future CUDA, ROCm, oneAPI validation work needs a single canonical place to declare precision class. Without this change, every per-backend addition would have to either re-derive the model or chase a cross-reference into the wrong file.

**Capabilities**: new `gpu-precision-classes` capability with 4 requirements covering the two-class model, per-class contracts, the accessor, and the shared tolerance constants.

## Change 3: `multi-vendor-gpu-rollout`

A **living roadmap** capturing the full multi-vendor rollout plan: Metal (Phase 1, in flight) → CUDA on ARM (Phase 2, waiting on DGX Spark) → CUDA on x86 (Phase 3) → ROCm (Phase 4) → oneAPI (Phase 5) → cross-vendor benchmark harness (Phase 6) → upstream contribution to postgis/postgis (Phase 7).

**Two unconventional choices**, both documented in design.md Decision 3:

1. **Planning artifact, not a code-level delta** — the proposal does not propose any source change. The spec defines a contract for HOW per-phase changes will be structured (the per-phase template), not what they will do at runtime.
2. **Never archived** — as phases complete, items in tasks.md get checked off and links to focused implementation OpenSpec changes are added inline. The change itself stays in `openspec/changes/` indefinitely as the canonical "where are we" reference.

The motivation for both is that the user explicitly preferred OpenSpec for planning ("I prefer to use openspec"), and a side-channel markdown roadmap would lose the validation, structure, and reviewability that OpenSpec provides. Accepting the unconventional choices is cheaper than fighting the workflow.

**Capabilities**: new `multi-vendor-gpu-rollout` capability with 4 requirements covering the living roadmap discipline, the per-phase template, hardware availability tracking, and the no-parallel-docs rule.

## Validation

All three changes pass `openspec validate`:

```
$ openspec validate metal-simd-era-precompute
Change 'metal-simd-era-precompute' is valid
$ openspec validate gpu-backend-precision-classes
Change 'gpu-backend-precision-classes' is valid
$ openspec validate multi-vendor-gpu-rollout
Change 'multi-vendor-gpu-rollout' is valid
```

Each change has all 4 standard artifacts (proposal, design, specs, tasks).

## Branch and dependencies

- **Branch**: `docs/gpu-roadmap-2026-04-11` (off current `develop`)
- **Depends on**: nothing in this PR (all three are planning-only)
- **Logically depends on**: PR #13 (`apple-metal-gpu-backend`) being merged first, so the Metal-specific cross-references and the precision-class extraction have a stable target. The roadmap explicitly references PR #13's status.
- **Spawns future PRs**: each phase in the roadmap will eventually spawn its own focused implementation PR. This PR does not implement any phase.

## Test plan

- [ ] CI green (lint/format checks only — no code to compile)
- [ ] All three OpenSpec changes validate
- [ ] Cross-references between the three changes are consistent (precision-classes referenced from multi-vendor-gpu-rollout, metal-simd-era-precompute referenced from multi-vendor-gpu-rollout Phase 1b)

## Open items not addressed by this PR

- **Implementation of any of the three changes** — that's the next set of focused PRs, spawned from the roadmap as hardware/time becomes available
- **Updates to the existing `apple-metal-gpu-backend` change** to cross-reference the new precision-classes capability — done as part of the precision-classes implementation, not in this planning PR
- **Promotion of `metal-simd-era-precompute` Phase 1b items in the roadmap to "in progress" status** — happens when implementation actually starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)