### PR TITLE
SonarCloud Phase 1: exclude test fixtures and vendored code

### DIFF
--- a/openspec/changes/sonarcloud-cleanup/tasks.md
+++ b/openspec/changes/sonarcloud-cleanup/tasks.md
@@ -17,11 +17,11 @@ This is a **living checklist**. Items get checked off as phases complete. Links 
 
 ## Phase 1: Path exclusions in sonar-project.properties
 
-**Status**: Not started. Blocked on Phase 0.
+**Status**: In progress on branch `feature/sonarcloud-phase1-exclusions` (commit 30620cc1d). CI verification pending (task 1.4).
 
-- [ ] 1.1 Open focused PR against develop titled "SonarCloud: exclude test fixtures and vendored code"
-- [ ] 1.2 Update `sonar-project.properties` `sonar.exclusions` value to include all TEST FIXTURE paths: `topology/test/**`, `raster/test/**`, `extras/ogc_test_suite/**`, `doc/html/images/styles.c` (in addition to the already-excluded `regress/**`, `**/cunit/**`, `**/test/**`, `fuzzers/**`, `extensions/**/sql/**`, `ci/**`, `deps/**`, `doc/**`)
-- [ ] 1.3 Add VENDORED file exclusions: `liblwgeom/lookup3.c`, `liblwgeom/lwin_wkt_lex.c`, `liblwgeom/lwin_wkt_parse.c`, `loader/dbfopen.c`, `loader/getopt.c`
+- [x] 1.1 Opened focused PR against develop titled "SonarCloud Phase 1: exclude test fixtures and vendored code" (branch `feature/sonarcloud-phase1-exclusions`)
+- [x] 1.2 Updated `sonar-project.properties` `sonar.exclusions` value to include TEST FIXTURE paths: `topology/test/**`, `raster/test/**`, `extras/ogc_test_suite/**`. `doc/html/images/styles.c` is already covered by the existing `doc/**` exclusion. All previous exclusions (`regress/**`, `**/cunit/**`, `**/test/**`, `fuzzers/**`, `extensions/**/sql/**`, `ci/**`, `deps/**`, `doc/**`) are preserved.
+- [x] 1.3 Added VENDORED file exclusions: `liblwgeom/lookup3.c`, `liblwgeom/lwin_wkt_lex.c`, `liblwgeom/lwin_wkt_parse.c`, `loader/dbfopen.c`, `loader/getopt.c`
 - [ ] 1.4 Before merging, run the `sonar.yml` workflow against the branch and confirm:
   - Blocker count drops from 152 toward 22 (target: ≤30)
   - No REAL issues were hidden by the new exclusions (cross-check a sample of excluded issues to confirm each is intentionally a test or vendored file)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,42 @@ sonar.organization=irongatelabs
 # Source directories to analyze
 sonar.sources=liblwgeom,postgis,raster/rt_core,raster/rt_pg,topology,sfcgal,loader,libpgcommon
 
-# Exclude test files, vendored deps, generated docs, and CI scripts
-sonar.exclusions=regress/**,deps/**,doc/**,**/cunit/**,**/test/**,extensions/**/sql/**,fuzzers/**,ci/**
+# Exclude test files, vendored deps, generated docs, and CI scripts.
+#
+# Classification model (see openspec/changes/sonarcloud-cleanup/):
+#
+# - TEST FIXTURE: intentional violations in regression test SQL,
+#   test harness code, and similar. These "bugs" exist on purpose
+#   to test the database engine's handling of the flagged pattern.
+#   Excluding these drops 96 of 152 blockers on the 2026-04-11
+#   baseline.
+#
+# - VENDORED: code maintained by an upstream project that PostGIS
+#   imports verbatim. PostGIS should NOT hand-modify these files;
+#   if a real bug is found, push the fix upstream to the vendor
+#   project rather than carry a local patch. Excluding these drops
+#   a further 34 of 152 blockers on the 2026-04-11 baseline.
+#
+# Between TEST FIXTURE and VENDORED exclusions, the expected blocker
+# count on a clean CI-driven analysis drops from 152 to roughly 22,
+# leaving only actionable real bugs in the dashboard.
+sonar.exclusions=\
+  regress/**,\
+  topology/test/**,\
+  raster/test/**,\
+  extras/ogc_test_suite/**,\
+  **/cunit/**,\
+  **/test/**,\
+  extensions/**/sql/**,\
+  fuzzers/**,\
+  ci/**,\
+  doc/**,\
+  deps/**,\
+  liblwgeom/lookup3.c,\
+  liblwgeom/lwin_wkt_lex.c,\
+  liblwgeom/lwin_wkt_parse.c,\
+  loader/dbfopen.c,\
+  loader/getopt.c
 
 # C/C++ file suffixes
 sonar.c.file.suffixes=.c,.h


### PR DESCRIPTION
## Summary

**Implements Phase 1** of the `sonarcloud-cleanup` OpenSpec initiative (see `openspec/changes/sonarcloud-cleanup/` on develop). This is the first focused implementation PR spawned from PR #15's phased cleanup plan.

Zero code changes — configuration only. Updates `sonar-project.properties` to add path exclusions for TEST FIXTURE and VENDORED code per the classification model established by the 2026-04-11 parallel-agent investigation.

## Expected impact

Before this PR, SonarCloud reported **152 blockers** on the project baseline (captured 2026-04-11 after Automatic Analysis was disabled and the CI-driven deep analysis started running).

| Classification | Count | This PR handles |
|---|---|---|
| REAL (first-party actionable) | 22 | ❌ Remains (targeted by Phases 3–5) |
| TEST FIXTURE | 96 | ✅ Excluded |
| VENDORED | 34 | ✅ Excluded |

**Target post-merge blocker count: ≤30** (ideally ~22, allowing some margin for edge cases in exclusion pattern matching).

## Changes

**`sonar-project.properties`** — expanded `sonar.exclusions`:

**Added TEST FIXTURE paths**:
- `topology/test/**` (69 blockers)
- `raster/test/**` (13 blockers)
- `extras/ogc_test_suite/**` (1 blocker)

(The existing patterns `regress/**`, `**/cunit/**`, `**/test/**`, `fuzzers/**`, `extensions/**/sql/**`, `ci/**`, `deps/**`, `doc/**` cover the remaining TEST FIXTURE items including `doc/html/images/styles.c`.)

**Added VENDORED file exclusions**:
- `liblwgeom/lookup3.c` — Bob Jenkins' public-domain hash function
- `liblwgeom/lwin_wkt_lex.c` — flex-generated WKT lexer
- `liblwgeom/lwin_wkt_parse.c` — bison-generated WKT parser
- `loader/dbfopen.c` — Shapelib upstream shapefile parser
- `loader/getopt.c` — AT&T public-domain getopt

Added a comment block explaining the classification model and linking to the OpenSpec change.

## Not included (targets of later phases)

| Phase | Target | What |
|---|---|---|
| **2** | NOSONAR markers | 3 false-positive "hard-coded password" vulnerabilities in `lwgeom_in_gml.c` (XPath templates flagged by regex) |
| **3** | Memory-safety fixes | `postgis/flatgeobuf.c:563` NULL deref, `liblwgeom/optionlist.c:112` missing return, `postgis/gserialized_estimate.c:1012-1035` negative index, `raster/rt_core/rt_wkb.c:543` memcpy OOB |
| **4** | `strtok` → `strtok_r` sweep | 8 sites across 5 files |
| **5** | Side-effect-in-logical-operator cleanup | 7 sites across 5 files |
| **6** | Long-tail rolling cleanup | Remaining ~8,000 code smells, ongoing |

Each later phase will be its own focused PR spawned from the cleanup roadmap.

## Verification

- [ ] After this PR's CI runs, check SonarCloud dashboard for the blocker count on this branch
- [ ] Confirm count drops from 152 to ≤30 (ideally ~22)
- [ ] Cross-check a sample of excluded issues to confirm each is intentionally a test fixture or vendored file (no REAL issues accidentally hidden)
- [ ] `openspec validate sonarcloud-cleanup` passes
- [ ] Phase 1 tasks 1.1, 1.2, 1.3 checked off in `openspec/changes/sonarcloud-cleanup/tasks.md`

## Tasks checklist mapping (from openspec)

| Task | Status |
|---|---|
| 1.1 Open focused PR | ✅ this PR |
| 1.2 TEST FIXTURE exclusions | ✅ committed |
| 1.3 VENDORED file exclusions | ✅ committed |
| 1.4 Verify blocker drop | ⏳ pending CI |
| 1.5 Merge | ⏳ pending review |
| 1.6 Record post-merge metrics | ⏳ follow-up commit after merge |

## Dependencies

- **Depends on**: PR #15 (`sonarcloud-cleanup` plan) — merged 2026-04-11T22:08:19Z ✅
- **Unblocks**: Phases 2–5 of the cleanup plan. Subsequent phases depend on the dashboard actually being usable (i.e., showing only the 22 real issues instead of 152 blockers dominated by noise).
- **Independent of**: PRs #13 (Metal), #14 (GPU roadmap), #2 (ECEF/ECI integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)