### PR TITLE
SonarCloud Phase 3a: memory-safety fixes (NULL derefs + PR #8 salvage)

### DIFF
--- a/liblwgeom/cunit/cu_misc.c
+++ b/liblwgeom/cunit/cu_misc.c
@@ -307,6 +307,14 @@ test_optionlist(void)
 	CU_ASSERT_EQUAL(2, sz);
 	ASSERT_STRING_EQUAL("key1=value1", olist[0]);
 	ASSERT_STRING_EQUAL("key2='value2 value3'", olist[1]);
+
+	/* SonarCloud S2259: input token lacking '=' separator previously
+	 * triggered NULL deref at `*val = '\0'` after lwerror returned. */
+	memset(olist, 0, sizeof(olist));
+	strcpy(input, "keywithoutvalue");
+	cu_error_msg_reset();
+	option_list_parse(input, olist);
+	ASSERT_STRING_EQUAL(cu_error_msg, "Option string entry 'keywithoutvalue' lacks separator '='");
 }
 
 static void

--- a/liblwgeom/cunit/cu_misc.c
+++ b/liblwgeom/cunit/cu_misc.c
@@ -19,8 +19,8 @@
 #include "stringlist.h"
 #include "cu_tester.h"
 
-
-static void test_misc_simplify(void)
+static void
+test_misc_simplify(void)
 {
 	LWGEOM *geom;
 	LWGEOM *geom2d;
@@ -29,7 +29,7 @@ static void test_misc_simplify(void)
 	geom = lwgeom_from_wkt("LINESTRING(0 0,0 10,0 51,50 20,30 20,7 32)", LW_PARSER_CHECK_NONE);
 	geom2d = lwgeom_simplify(geom, 2, LW_FALSE);
 	wkt_out = lwgeom_to_ewkt(geom2d);
-	ASSERT_STRING_EQUAL("LINESTRING(0 0,0 51,50 20,30 20,7 32)",wkt_out);
+	ASSERT_STRING_EQUAL("LINESTRING(0 0,0 51,50 20,30 20,7 32)", wkt_out);
 	lwgeom_free(geom);
 	lwgeom_free(geom2d);
 	lwfree(wkt_out);
@@ -37,7 +37,7 @@ static void test_misc_simplify(void)
 	geom = lwgeom_from_wkt("MULTILINESTRING((0 0,0 10,0 51,50 20,30 20,7 32))", LW_PARSER_CHECK_NONE);
 	geom2d = lwgeom_simplify(geom, 2, LW_FALSE);
 	wkt_out = lwgeom_to_ewkt(geom2d);
-	ASSERT_STRING_EQUAL("MULTILINESTRING((0 0,0 51,50 20,30 20,7 32))",wkt_out);
+	ASSERT_STRING_EQUAL("MULTILINESTRING((0 0,0 51,50 20,30 20,7 32))", wkt_out);
 	lwgeom_free(geom);
 	lwgeom_free(geom2d);
 	lwfree(wkt_out);
@@ -51,7 +51,8 @@ static void test_misc_simplify(void)
 	lwfree(wkt_out);
 }
 
-static void test_misc_startpoint(void)
+static void
+test_misc_startpoint(void)
 {
 	LWGEOM *geom;
 	POINT4D p = {0};
@@ -81,39 +82,46 @@ static void test_misc_startpoint(void)
 	lwgeom_free(geom);
 }
 
-static void test_misc_count_vertices(void)
+static void
+test_misc_count_vertices(void)
 {
 	LWGEOM *geom;
 	int count;
 
-	geom = lwgeom_from_wkt("GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1),POLYGON((0 0,0 1,1 0,0 0)),CIRCULARSTRING(0 0,0 1,1 1),CURVEPOLYGON(CIRCULARSTRING(0 0,0 1,1 1)))", LW_PARSER_CHECK_NONE);
+	geom = lwgeom_from_wkt(
+	    "GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(0 0,1 1),POLYGON((0 0,0 1,1 0,0 0)),CIRCULARSTRING(0 0,0 1,1 1),CURVEPOLYGON(CIRCULARSTRING(0 0,0 1,1 1)))",
+	    LW_PARSER_CHECK_NONE);
 	count = lwgeom_count_vertices(geom);
-	CU_ASSERT_EQUAL(count,13);
+	CU_ASSERT_EQUAL(count, 13);
 	lwgeom_free(geom);
 
-	geom = lwgeom_from_wkt("GEOMETRYCOLLECTION(CIRCULARSTRING(0 0,0 1,1 1),POINT(0 0),CURVEPOLYGON(CIRCULARSTRING(0 0,0 1,1 1,1 0,0 0)))", LW_PARSER_CHECK_NONE);
+	geom = lwgeom_from_wkt(
+	    "GEOMETRYCOLLECTION(CIRCULARSTRING(0 0,0 1,1 1),POINT(0 0),CURVEPOLYGON(CIRCULARSTRING(0 0,0 1,1 1,1 0,0 0)))",
+	    LW_PARSER_CHECK_NONE);
 	count = lwgeom_count_vertices(geom);
-	CU_ASSERT_EQUAL(count,9);
+	CU_ASSERT_EQUAL(count, 9);
 	lwgeom_free(geom);
 
-	geom = lwgeom_from_wkt("CURVEPOLYGON((0 0,1 0,0 1,0 0),CIRCULARSTRING(0 0,1 0,1 1,1 0,0 0))", LW_PARSER_CHECK_NONE);
+	geom = lwgeom_from_wkt("CURVEPOLYGON((0 0,1 0,0 1,0 0),CIRCULARSTRING(0 0,1 0,1 1,1 0,0 0))",
+			       LW_PARSER_CHECK_NONE);
 	count = lwgeom_count_vertices(geom);
-	CU_ASSERT_EQUAL(count,9);
+	CU_ASSERT_EQUAL(count, 9);
 	lwgeom_free(geom);
-
 
 	geom = lwgeom_from_wkt("POLYGON((0 0,1 0,0 1,0 0))", LW_PARSER_CHECK_NONE);
 	count = lwgeom_count_vertices(geom);
-	CU_ASSERT_EQUAL(count,4);
+	CU_ASSERT_EQUAL(count, 4);
 	lwgeom_free(geom);
 
-	geom = lwgeom_from_wkt("CURVEPOLYGON((0 0,1 0,0 1,0 0),CIRCULARSTRING(0 0,1 0,1 1,1 0,0 0))", LW_PARSER_CHECK_NONE);
+	geom = lwgeom_from_wkt("CURVEPOLYGON((0 0,1 0,0 1,0 0),CIRCULARSTRING(0 0,1 0,1 1,1 0,0 0))",
+			       LW_PARSER_CHECK_NONE);
 	count = lwgeom_count_vertices(geom);
-	CU_ASSERT_EQUAL(count,9);
+	CU_ASSERT_EQUAL(count, 9);
 	lwgeom_free(geom);
 }
 
-static void test_misc_area(void)
+static void
+test_misc_area(void)
 {
 	LWGEOM *geom;
 	double area;
@@ -124,19 +132,21 @@ static void test_misc_area(void)
 	lwgeom_free(geom);
 }
 
-static void test_misc_wkb(void)
+static void
+test_misc_wkb(void)
 {
-	static char *wkb = "010A0000000200000001080000000700000000000000000000C00000000000000000000000000000F0BF000000000000F0BF00000000000000000000000000000000000000000000F03F000000000000F0BF000000000000004000000000000000000000000000000000000000000000004000000000000000C00000000000000000010200000005000000000000000000F0BF00000000000000000000000000000000000000000000E03F000000000000F03F00000000000000000000000000000000000000000000F03F000000000000F0BF0000000000000000";
+	static char *wkb =
+	    "010A0000000200000001080000000700000000000000000000C00000000000000000000000000000F0BF000000000000F0BF00000000000000000000000000000000000000000000F03F000000000000F0BF000000000000004000000000000000000000000000000000000000000000004000000000000000C00000000000000000010200000005000000000000000000F0BF00000000000000000000000000000000000000000000E03F000000000000F03F00000000000000000000000000000000000000000000F03F000000000000F0BF0000000000000000";
 	LWGEOM *geom = lwgeom_from_hexwkb(wkb, LW_PARSER_CHECK_ALL);
 	char *str = lwgeom_to_wkt(geom, WKB_ISO, 8, 0);
-	ASSERT_STRING_EQUAL(str, "CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0))");
+	ASSERT_STRING_EQUAL(str,
+			    "CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0))");
 	lwfree(str);
 	lwgeom_free(geom);
-
 }
 
-
-static void test_grid(void)
+static void
+test_grid(void)
 {
 	gridspec grid;
 	static char *wkt = "MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)))";
@@ -155,7 +165,8 @@ static void test_grid(void)
 	lwgeom_free(geomgrid);
 }
 
-static void do_grid_test(const char *wkt_in, const char *wkt_out, double size)
+static void
+do_grid_test(const char *wkt_in, const char *wkt_out, double size)
 {
 	char *wkt_result, *wkt_norm;
 	gridspec grid;
@@ -166,7 +177,7 @@ static void do_grid_test(const char *wkt_in, const char *wkt_out, double size)
 	grid.xsize = grid.ysize = grid.zsize = grid.msize = size;
 	lwgeom_grid_in_place(g, &grid);
 	wkt_result = lwgeom_to_ewkt(g);
-    // printf("%s ==%ld==> %s == %s\n", wkt_in, lround(size), wkt_result, wkt_out);
+	// printf("%s ==%ld==> %s == %s\n", wkt_in, lround(size), wkt_result, wkt_out);
 	ASSERT_STRING_EQUAL(wkt_result, wkt_norm);
 	lwfree(wkt_result);
 	lwfree(wkt_norm);
@@ -174,59 +185,32 @@ static void do_grid_test(const char *wkt_in, const char *wkt_out, double size)
 	lwgeom_free(go);
 }
 
-static void test_grid_in_place(void)
+static void
+test_grid_in_place(void)
 {
-	do_grid_test(
-		"LINESTRING(0 0,1 1,1 1,1 1)",
-		"LINESTRING(0 0,1 1)",
-		0.001
-	);
-	do_grid_test(
-		"POINT ZM (5.1423999999 5.1423999999 5.1423999999 5.1423999999)",
-		"POINT(5.1424 5.1424 5.1424 5.1424)",
-		0.0001
-	);
-	do_grid_test(
-		"MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))",
-		"MULTIPOLYGON EMPTY",
-		20
-	);
-	do_grid_test(
-		"MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))",
-		"MULTIPOLYGON(((0 0,10 0,10 10, 0 10,0 0)))",
-		1
-	);
-	do_grid_test(
-		"LINESTRING(0 0,1 1, 2 2, 3 3, 4 4, 5 5)",
-		"LINESTRING(0 0,2 2,4 4)",
-		2
-	);
-	do_grid_test(
-		"MULTIPOINT(0 0,1 1, 2 2, 3 3, 4 4, 5 5)",
-		/* This preserves current behaviour, but is probably not right */
-		"MULTIPOINT(0 0,0 0,2 2,4 4,4 4,4 4)",
-		2
-	);
-	do_grid_test(
-		"MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(4 4, 4 5, 5 5, 5 4, 4 4)))",
-		"MULTIPOLYGON(((0 0,10 0,10 10, 0 10,0 0)))",
-		2
-	);
-	do_grid_test(
-		"MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(4 4, 4 5, 5 5, 5 4, 4 4)))",
-		"MULTIPOLYGON EMPTY",
-		20
-	);
-	do_grid_test(
-		"POINT Z (5 5 5)",
-		"POINT(0 0 0)",
-		20
-	);
+	do_grid_test("LINESTRING(0 0,1 1,1 1,1 1)", "LINESTRING(0 0,1 1)", 0.001);
+	do_grid_test("POINT ZM (5.1423999999 5.1423999999 5.1423999999 5.1423999999)",
+		     "POINT(5.1424 5.1424 5.1424 5.1424)",
+		     0.0001);
+	do_grid_test("MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))", "MULTIPOLYGON EMPTY", 20);
+	do_grid_test("MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))", "MULTIPOLYGON(((0 0,10 0,10 10, 0 10,0 0)))", 1);
+	do_grid_test("LINESTRING(0 0,1 1, 2 2, 3 3, 4 4, 5 5)", "LINESTRING(0 0,2 2,4 4)", 2);
+	do_grid_test("MULTIPOINT(0 0,1 1, 2 2, 3 3, 4 4, 5 5)",
+		     /* This preserves current behaviour, but is probably not right */
+		     "MULTIPOINT(0 0,0 0,2 2,4 4,4 4,4 4)",
+		     2);
+	do_grid_test("MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(4 4, 4 5, 5 5, 5 4, 4 4)))",
+		     "MULTIPOLYGON(((0 0,10 0,10 10, 0 10,0 0)))",
+		     2);
+	do_grid_test("MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(4 4, 4 5, 5 5, 5 4, 4 4)))", "MULTIPOLYGON EMPTY", 20);
+	do_grid_test("POINT Z (5 5 5)", "POINT(0 0 0)", 20);
 }
 
-static void test_clone(void)
+static void
+test_clone(void)
 {
-	static char *wkt = "GEOMETRYCOLLECTION(MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0))),POINT(1 1),LINESTRING(2 3,4 5))";
+	static char *wkt =
+	    "GEOMETRYCOLLECTION(MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0))),POINT(1 1),LINESTRING(2 3,4 5))";
 	LWGEOM *geom1 = lwgeom_from_wkt(wkt, LW_PARSER_CHECK_ALL);
 	LWGEOM *geom2;
 
@@ -242,38 +226,49 @@ static void test_clone(void)
 	lwgeom_free(geom1);
 }
 
-static void test_lwmpoint_from_lwgeom(void)
+static void
+test_lwmpoint_from_lwgeom(void)
 {
 	/* This cast is so ugly, we only want to do it once.  And not even that. */
-	LWGEOM* (*to_points)(LWGEOM*) = (LWGEOM* (*)(LWGEOM*)) &lwmpoint_from_lwgeom;
+	LWGEOM *(*to_points)(LWGEOM *) = (LWGEOM * (*)(LWGEOM *)) & lwmpoint_from_lwgeom;
 
 	do_fn_test(to_points, "MULTIPOLYGON (EMPTY)", "MULTIPOINT EMPTY");
 	do_fn_test(to_points, "POINT (30 10)", "MULTIPOINT ((30 10))");
 	do_fn_test(to_points, "LINESTRING Z (30 10 4,10 30 5,40 40 6)", "MULTIPOINT Z (30 10 4,10 30 5, 40 40 6)");
-	do_fn_test(to_points, "POLYGON((35 10,45 45,15 40,10 20,35 10),(20 30,35 35,30 20,20 30))", "MULTIPOINT(35 10,45 45,15 40,10 20,35 10,20 30,35 35,30 20,20 30)");
-	do_fn_test(to_points, "MULTIPOINT M (10 40 1,40 30 2,20 20 3,30 10 4)", "MULTIPOINT M (10 40 1,40 30 2,20 20 3,30 10 4)");
-	do_fn_test(to_points, "COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0))", "MULTIPOINT(0 0, 2 0, 2 1, 2 3, 4 3, 4 3, 4 5, 1 4, 0 0)");
-	do_fn_test(to_points, "TIN(((80 130,50 160,80 70,80 130)),((50 160,10 190,10 70,50 160)))", "MULTIPOINT (80 130, 50 160, 80 70, 80 130, 50 160, 10 190, 10 70, 50 160)");
+	do_fn_test(to_points,
+		   "POLYGON((35 10,45 45,15 40,10 20,35 10),(20 30,35 35,30 20,20 30))",
+		   "MULTIPOINT(35 10,45 45,15 40,10 20,35 10,20 30,35 35,30 20,20 30)");
+	do_fn_test(to_points,
+		   "MULTIPOINT M (10 40 1,40 30 2,20 20 3,30 10 4)",
+		   "MULTIPOINT M (10 40 1,40 30 2,20 20 3,30 10 4)");
+	do_fn_test(to_points,
+		   "COMPOUNDCURVE(CIRCULARSTRING(0 0,2 0, 2 1, 2 3, 4 3),(4 3, 4 5, 1 4, 0 0))",
+		   "MULTIPOINT(0 0, 2 0, 2 1, 2 3, 4 3, 4 3, 4 5, 1 4, 0 0)");
+	do_fn_test(to_points,
+		   "TIN(((80 130,50 160,80 70,80 130)),((50 160,10 190,10 70,50 160)))",
+		   "MULTIPOINT (80 130, 50 160, 80 70, 80 130, 50 160, 10 190, 10 70, 50 160)");
 }
 
-static void test_gbox_serialized_size(void)
+static void
+test_gbox_serialized_size(void)
 {
 	lwflags_t flags = lwflags(0, 0, 0);
-	CU_ASSERT_EQUAL(gbox_serialized_size(flags),16);
+	CU_ASSERT_EQUAL(gbox_serialized_size(flags), 16);
 	FLAGS_SET_BBOX(flags, 1);
-	CU_ASSERT_EQUAL(gbox_serialized_size(flags),16);
+	CU_ASSERT_EQUAL(gbox_serialized_size(flags), 16);
 	FLAGS_SET_Z(flags, 1);
-	CU_ASSERT_EQUAL(gbox_serialized_size(flags),24);
+	CU_ASSERT_EQUAL(gbox_serialized_size(flags), 24);
 	FLAGS_SET_M(flags, 1);
-	CU_ASSERT_EQUAL(gbox_serialized_size(flags),32);
+	CU_ASSERT_EQUAL(gbox_serialized_size(flags), 32);
 	FLAGS_SET_GEODETIC(flags, 1);
-	CU_ASSERT_EQUAL(gbox_serialized_size(flags),24);
+	CU_ASSERT_EQUAL(gbox_serialized_size(flags), 24);
 }
 
-static void test_optionlist(void)
+static void
+test_optionlist(void)
 {
 	size_t sz;
-	const char* value;
+	const char *value;
 	// zero out all the pointers so our list ends up null-terminated
 	char *olist[OPTION_LIST_SIZE];
 	char input[128];
@@ -314,8 +309,8 @@ static void test_optionlist(void)
 	ASSERT_STRING_EQUAL("key2='value2 value3'", olist[1]);
 }
 
-
-static void test_stringlist(void)
+static void
+test_stringlist(void)
 {
 	stringlist_t s;
 	stringlist_init(&s);
@@ -341,12 +336,12 @@ static void test_stringlist(void)
 	stringlist_release(&s);
 }
 
-
 /*
 ** Used by the test harness to register the tests in this file.
 */
 void misc_suite_setup(void);
-void misc_suite_setup(void)
+void
+misc_suite_setup(void)
 {
 	CU_pSuite suite = CU_add_suite("miscellaneous", NULL, NULL);
 	PG_ADD_TEST(suite, test_misc_simplify);

--- a/liblwgeom/optionlist.c
+++ b/liblwgeom/optionlist.c
@@ -122,6 +122,7 @@ option_list_parse(char *input, char **olist)
 		if (!val)
 		{
 			lwerror("Option string entry '%s' lacks separator '%c'", key, kvsep);
+			return;
 		}
 		/* null out the separator */
 		*val = '\0';

--- a/liblwgeom/optionlist.c
+++ b/liblwgeom/optionlist.c
@@ -29,10 +29,12 @@
 #include <string.h> // strtok
 
 static void
-option_list_string_to_lower(char* key)
+option_list_string_to_lower(char *key)
 {
-	if (!key) return;
-	while (*key) {
+	if (!key)
+		return;
+	while (*key)
+	{
 		*key = tolower(*key);
 		key++;
 	}
@@ -50,18 +52,23 @@ option_list_string_to_lower(char* key)
 // 	return;
 // }
 
-const char*
-option_list_search(char** olist, const char* key)
+const char *
+option_list_search(char **olist, const char *key)
 {
 	size_t i = 0;
-	if (!olist) return NULL;
-	if (!key) return NULL;
-	while (olist[i]) {
+	if (!olist)
+		return NULL;
+	if (!key)
+		return NULL;
+	while (olist[i])
+	{
 		// Even entries are keys
-		if (!(i % 2)) {
+		if (!(i % 2))
+		{
 			// Does this key match ours?
-			if (strcmp(olist[i], key) == 0) {
-				return olist[i+1];
+			if (strcmp(olist[i], key) == 0)
+			{
+				return olist[i + 1];
 			}
 		}
 		i++;
@@ -70,12 +77,14 @@ option_list_search(char** olist, const char* key)
 }
 
 size_t
-option_list_length(char** olist)
+option_list_length(char **olist)
 {
 	size_t i = 0;
 	char **iter = olist;
-	if (!olist) return 0;
-	while(*iter) {
+	if (!olist)
+		return 0;
+	while (*iter)
+	{
 		i++;
 		iter++;
 	}
@@ -83,42 +92,48 @@ option_list_length(char** olist)
 }
 
 void
-option_list_parse(char* input, char** olist)
+option_list_parse(char *input, char **olist)
 {
 	const char *toksep = " ";
 	const char kvsep = '=';
 	char *key, *val;
-	if (!input) return;
+	if (!input)
+		return;
 	size_t i = 0, sz;
 
 	/* strtok nulls out the space between each token */
-	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep)) {
-		if (i >= OPTION_LIST_SIZE) return;
+	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep))
+	{
+		if (i >= OPTION_LIST_SIZE)
+			return;
 		olist[i] = key;
 		i += 2;
 	}
 
 	sz = i;
 	/* keys are every second entry in the olist */
-	for (i = 0; i < sz; i += 2) {
-		if (i >= OPTION_LIST_SIZE) return;
+	for (i = 0; i < sz; i += 2)
+	{
+		if (i >= OPTION_LIST_SIZE)
+			return;
 		key = olist[i];
 		/* find the key/value separator */
 		val = strchr(key, kvsep);
-		if (!val) {
+		if (!val)
+		{
 			lwerror("Option string entry '%s' lacks separator '%c'", key, kvsep);
 		}
 		/* null out the separator */
 		*val = '\0';
 		/* point value entry to just after separator */
-		olist[i+1] = ++val;
+		olist[i + 1] = ++val;
 		/* all keys forced to lower case */
 		option_list_string_to_lower(key);
 	}
 }
 
 void
-option_list_gdal_parse(char* input, char** olist)
+option_list_gdal_parse(char *input, char **olist)
 {
 	const char *toksep = " ";
 	const char kvsep = '=';
@@ -136,7 +151,8 @@ option_list_gdal_parse(char* input, char** olist)
 	input_sz = strlen(input);
 
 	/* Temporarily hide quoted spaces */
-	while(*ptr) {
+	while (*ptr)
+	{
 		if (*ptr == q2 || *ptr == q1)
 			in_str = !in_str;
 		else if (in_str && *ptr == ' ')
@@ -146,28 +162,33 @@ option_list_gdal_parse(char* input, char** olist)
 	}
 
 	/* Tokenize on spaces */
-	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep)) {
-		if (i >= OPTION_LIST_SIZE) return;
+	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep))
+	{
+		if (i >= OPTION_LIST_SIZE)
+			return;
 		olist[i++] = key;
 	}
 
 	/* Check that these are GDAL KEY=VALUE options */
 	sz = i;
-	for (i = 0; i < sz; ++i) {
-		if (i >= OPTION_LIST_SIZE) return;
+	for (i = 0; i < sz; ++i)
+	{
+		if (i >= OPTION_LIST_SIZE)
+			return;
 		key = olist[i];
 		/* find the key/value separator */
 		val = strchr(key, kvsep);
-		if (!val) {
+		if (!val)
+		{
 			lwerror("Option string entry '%s' lacks separator '%c'", key, kvsep);
 			return;
 		}
 	}
 
 	/* Unhide quoted space */
-	for (i = 0; i <= input_sz; ++i) {
+	for (i = 0; i <= input_sz; ++i)
+	{
 		if (input[i] == notspace)
 			input[i] = ' ';
 	}
 }
-

--- a/postgis/flatgeobuf.c
+++ b/postgis/flatgeobuf.c
@@ -587,9 +587,9 @@ flatgeobuf_agg_transfn(struct flatgeobuf_agg_ctx *ctx)
 uint8_t *
 flatgeobuf_agg_finalfn(struct flatgeobuf_agg_ctx *ctx)
 {
-	POSTGIS_DEBUGF(3, "called at offset %lld", ctx->ctx->offset);
 	if (ctx == NULL)
-		flatgeobuf_agg_ctx_init(NULL, false);
+		ctx = flatgeobuf_agg_ctx_init(NULL, false);
+	POSTGIS_DEBUGF(3, "called at offset %lld", ctx->ctx->offset);
 	// header only result
 	if (ctx->ctx->features_count == 0)
 	{

--- a/postgis/flatgeobuf.c
+++ b/postgis/flatgeobuf.c
@@ -33,7 +33,9 @@
 #include "utils/datetime.h"
 #include "utils/jsonb.h"
 
-static uint8_t get_column_type(Oid typoid) {
+static uint8_t
+get_column_type(Oid typoid)
+{
 	switch (typoid)
 	{
 	case BOOLOID:
@@ -61,11 +63,11 @@ static uint8_t get_column_type(Oid typoid) {
 	case TIMESTAMPTZOID:
 		return flatgeobuf_column_type_datetime;
 	}
-	elog(ERROR, "flatgeobuf: get_column_type: '%d' column type not supported",
-		typoid);
+	elog(ERROR, "flatgeobuf: get_column_type: '%d' column type not supported", typoid);
 }
 
-static void inspect_table(struct flatgeobuf_agg_ctx *ctx)
+static void
+inspect_table(struct flatgeobuf_agg_ctx *ctx)
 {
 	flatgeobuf_column *c;
 	flatgeobuf_column **columns;
@@ -83,18 +85,24 @@ static void inspect_table(struct flatgeobuf_agg_ctx *ctx)
 
 	// inspect columns
 	// NOTE: last element will be unused if geom attr is found
-	for (int i = 0; i < natts; i++) {
+	for (int i = 0; i < natts; i++)
+	{
 		Oid typoid = getBaseType(TupleDescAttr(tupdesc, i)->atttypid);
 		const char *key = TupleDescAttr(tupdesc, i)->attname.data;
 		POSTGIS_DEBUGF(2, "inspecting column definition for %s with oid %d", key, typoid);
-		if (ctx->geom_name == NULL) {
-			if (!geom_found && typoid == postgis_oid(GEOMETRYOID)) {
+		if (ctx->geom_name == NULL)
+		{
+			if (!geom_found && typoid == postgis_oid(GEOMETRYOID))
+			{
 				ctx->geom_index = i;
 				geom_found = true;
 				continue;
 			}
-		} else {
-			if (!geom_found && strcmp(key, ctx->geom_name) == 0) {
+		}
+		else
+		{
+			if (!geom_found && strcmp(key, ctx->geom_name) == 0)
+			{
 				ctx->geom_index = i;
 				geom_found = true;
 				continue;
@@ -102,7 +110,7 @@ static void inspect_table(struct flatgeobuf_agg_ctx *ctx)
 		}
 		POSTGIS_DEBUGF(2, "creating column definition for %s with oid %d", key, typoid);
 
-		c = (flatgeobuf_column *) palloc0(sizeof(flatgeobuf_column));
+		c = (flatgeobuf_column *)palloc0(sizeof(flatgeobuf_column));
 		c->name = pstrdup(key);
 		c->type = get_column_type(typoid);
 		columns[columns_size] = c;
@@ -112,21 +120,25 @@ static void inspect_table(struct flatgeobuf_agg_ctx *ctx)
 	if (!geom_found)
 		elog(ERROR, "no geom column found");
 
-	if (columns_size > 0) {
+	if (columns_size > 0)
+	{
 		ctx->ctx->columns = columns;
 		ctx->ctx->columns_size = columns_size;
 	}
 }
 
 // ensure properties has room for at least size
-static void ensure_properties_size(struct flatgeobuf_agg_ctx *ctx, size_t size)
+static void
+ensure_properties_size(struct flatgeobuf_agg_ctx *ctx, size_t size)
 {
-	if (ctx->ctx->properties_size == 0) {
+	if (ctx->ctx->properties_size == 0)
+	{
 		ctx->ctx->properties_size = 1024 * 4;
 		POSTGIS_DEBUGF(2, "flatgeobuf: properties buffer to size %d", ctx->ctx->properties_size);
 		ctx->ctx->properties = palloc(ctx->ctx->properties_size);
 	}
-	if (ctx->ctx->properties_size < size) {
+	if (ctx->ctx->properties_size < size)
+	{
 		ctx->ctx->properties_size = ctx->ctx->properties_size * 2;
 		POSTGIS_DEBUGF(2, "flatgeobuf: reallocating properties buffer to size %d", ctx->ctx->properties_size);
 		ctx->ctx->properties = repalloc(ctx->ctx->properties, ctx->ctx->properties_size);
@@ -135,13 +147,16 @@ static void ensure_properties_size(struct flatgeobuf_agg_ctx *ctx, size_t size)
 }
 
 // ensure items have room for at least ctx->ctx->features_count + 1
-static void ensure_items_len(struct flatgeobuf_agg_ctx *ctx)
+static void
+ensure_items_len(struct flatgeobuf_agg_ctx *ctx)
 {
-	if (ctx->ctx->features_count == 0) {
+	if (ctx->ctx->features_count == 0)
+	{
 		ctx->ctx->items_len = 32;
 		ctx->ctx->items = palloc(sizeof(flatgeobuf_item *) * ctx->ctx->items_len);
 	}
-	if (ctx->ctx->items_len < (ctx->ctx->features_count + 1)) {
+	if (ctx->ctx->items_len < (ctx->ctx->features_count + 1))
+	{
 		ctx->ctx->items_len = ctx->ctx->items_len * 2;
 		POSTGIS_DEBUGF(2, "flatgeobuf: reallocating items to len %lld", ctx->ctx->items_len);
 		ctx->ctx->items = repalloc(ctx->ctx->items, sizeof(flatgeobuf_item *) * ctx->ctx->items_len);
@@ -149,7 +164,8 @@ static void ensure_items_len(struct flatgeobuf_agg_ctx *ctx)
 	}
 }
 
-static void encode_properties(flatgeobuf_agg_ctx *ctx)
+static void
+encode_properties(flatgeobuf_agg_ctx *ctx)
 {
 	uint16_t ci = 0;
 	size_t offset = 0;
@@ -167,9 +183,10 @@ static void encode_properties(flatgeobuf_agg_ctx *ctx)
 	double double_value;
 	char *string_value;
 
-	//Jsonb *jb;
+	// Jsonb *jb;
 
-	for (i = 0; i < (uint32_t) ctx->tupdesc->natts; i++) {
+	for (i = 0; i < (uint32_t)ctx->tupdesc->natts; i++)
+	{
 		if (ctx->geom_index == i)
 			continue;
 		datum = GetAttributeByNum(ctx->row, i + 1, &isnull);
@@ -179,7 +196,8 @@ static void encode_properties(flatgeobuf_agg_ctx *ctx)
 		memcpy(ctx->ctx->properties + offset, &ci, sizeof(ci));
 		offset += sizeof(ci);
 		typoid = getBaseType(TupleDescAttr(ctx->tupdesc, i)->atttypid);
-		switch (typoid) {
+		switch (typoid)
+		{
 		case BOOLOID:
 			byte_value = DatumGetBool(datum) ? 1 : 0;
 			ensure_properties_size(ctx, offset + sizeof(byte_value));
@@ -245,27 +263,29 @@ static void encode_properties(flatgeobuf_agg_ctx *ctx)
 			offset += len;
 			break;
 		}
-		// TODO: handle date/time types
-		// case JSONBOID:
-		// 	jb = DatumGetJsonbP(datum);
-		// 	string_value = JsonbToCString(NULL, &jb->root, VARSIZE(jb));
-		// 	len = strlen(string_value);
-		// 	memcpy(data + offset, &len, sizeof(len));
-		// 	offset += sizeof(len);
-		// 	memcpy(data + offset, string_value, len);
-		// 	offset += len;
-		// 	break;
+			// TODO: handle date/time types
+			// case JSONBOID:
+			// 	jb = DatumGetJsonbP(datum);
+			// 	string_value = JsonbToCString(NULL, &jb->root, VARSIZE(jb));
+			// 	len = strlen(string_value);
+			// 	memcpy(data + offset, &len, sizeof(len));
+			// 	offset += sizeof(len);
+			// 	memcpy(data + offset, string_value, len);
+			// 	offset += len;
+			// 	break;
 		}
 		ci++;
 	}
 
-	if (offset > 0) {
+	if (offset > 0)
+	{
 		POSTGIS_DEBUGF(3, "offset %ld", offset);
 		ctx->ctx->properties_len = offset;
 	}
 }
 
-void flatgeobuf_check_magicbytes(struct flatgeobuf_decode_ctx *ctx)
+void
+flatgeobuf_check_magicbytes(struct flatgeobuf_decode_ctx *ctx)
 {
 	uint8_t *buf = ctx->ctx->buf + ctx->ctx->offset;
 	uint32_t i;
@@ -276,7 +296,8 @@ void flatgeobuf_check_magicbytes(struct flatgeobuf_decode_ctx *ctx)
 	ctx->ctx->offset += FLATGEOBUF_MAGICBYTES_SIZE;
 }
 
-static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, bool *isnull)
+static void
+decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, bool *isnull)
 {
 	uint16_t i, ci;
 	flatgeobuf_column *column;
@@ -291,7 +312,8 @@ static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, 
 
 	if (size > 0 && size < (sizeof(uint16_t) + sizeof(uint8_t)))
 		elog(ERROR, "flatgeobuf: decode_properties: Unexpected properties data size %d", size);
-	while (offset + 1 < size) {
+	while (offset + 1 < size)
+	{
 		if (offset + sizeof(uint16_t) > size)
 			elog(ERROR, "flatgeobuf: decode_properties: Unexpected offset %d", offset);
 		memcpy(&i, data + offset, sizeof(uint16_t));
@@ -302,7 +324,8 @@ static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, 
 		column = ctx->ctx->columns[i];
 		type = column->type;
 		isnull[ci] = false;
-		switch (type) {
+		switch (type)
+		{
 		case flatgeobuf_column_type_bool: {
 			uint8_t value;
 			if (offset + sizeof(uint8_t) > size)
@@ -408,7 +431,7 @@ static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, 
 				elog(ERROR, "flatgeobuf: decode_properties: Invalid size for string value");
 			memcpy(&len, data + offset, sizeof(uint32_t));
 			offset += sizeof(len);
-			values[ci] = PointerGetDatum(cstring_to_text_with_len((const char *) data + offset, len));
+			values[ci] = PointerGetDatum(cstring_to_text_with_len((const char *)data + offset, len));
 			offset += len;
 			break;
 		}
@@ -432,8 +455,8 @@ static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, 
 			memcpy(&len, data + offset, sizeof(uint32_t));
 			offset += sizeof(len);
 			buf = palloc0(len + 1);
-			memcpy(buf, (const char *) data + offset, len);
-			ParseDateTime((const char *) buf, workbuf, sizeof(workbuf), field, ftype, MAXDATEFIELDS, &nf);
+			memcpy(buf, (const char *)data + offset, len);
+			ParseDateTime((const char *)buf, workbuf, sizeof(workbuf), field, ftype, MAXDATEFIELDS, &nf);
 
 #if POSTGIS_PGSQL_VERSION >= 160
 			DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, &tzp, &extra);
@@ -458,10 +481,10 @@ static void decode_properties(struct flatgeobuf_decode_ctx *ctx, Datum *values, 
 			elog(ERROR, "flatgeobuf: decode_properties: Unknown type %d", type);
 		}
 	}
-
 }
 
-void flatgeobuf_decode_row(struct flatgeobuf_decode_ctx *ctx)
+void
+flatgeobuf_decode_row(struct flatgeobuf_decode_ctx *ctx)
 {
 	HeapTuple heapTuple;
 	uint32_t natts = ctx->tupdesc->natts;
@@ -474,9 +497,12 @@ void flatgeobuf_decode_row(struct flatgeobuf_decode_ctx *ctx)
 	if (flatgeobuf_decode_feature(ctx->ctx))
 		elog(ERROR, "flatgeobuf_decode_feature: unsuccessful");
 
-	if (ctx->ctx->lwgeom != NULL) {
+	if (ctx->ctx->lwgeom != NULL)
+	{
 		values[1] = PointerGetDatum(geometry_serialize(ctx->ctx->lwgeom));
-	} else {
+	}
+	else
+	{
 		POSTGIS_DEBUG(3, "geometry is null");
 		isnull[1] = true;
 	}
@@ -490,7 +516,8 @@ void flatgeobuf_decode_row(struct flatgeobuf_decode_ctx *ctx)
 
 	POSTGIS_DEBUGF(3, "fid now %d", ctx->fid);
 
-	if (ctx->ctx->offset == ctx->ctx->size) {
+	if (ctx->ctx->offset == ctx->ctx->size)
+	{
 		POSTGIS_DEBUGF(3, "reached end at %lld", ctx->ctx->offset);
 		ctx->done = true;
 	}
@@ -499,7 +526,8 @@ void flatgeobuf_decode_row(struct flatgeobuf_decode_ctx *ctx)
 /**
  * Initialize aggregation context.
  */
-struct flatgeobuf_agg_ctx *flatgeobuf_agg_ctx_init(const char *geom_name, const bool create_index)
+struct flatgeobuf_agg_ctx *
+flatgeobuf_agg_ctx_init(const char *geom_name, const bool create_index)
 {
 	struct flatgeobuf_agg_ctx *ctx;
 	size_t size = VARHDRSZ + FLATGEOBUF_MAGICBYTES_SIZE;
@@ -523,7 +551,8 @@ struct flatgeobuf_agg_ctx *flatgeobuf_agg_ctx_init(const char *geom_name, const 
  * Allocates a new feature, increment feature counter and
  * encode properties into it.
  */
-void flatgeobuf_agg_transfn(struct flatgeobuf_agg_ctx *ctx)
+void
+flatgeobuf_agg_transfn(struct flatgeobuf_agg_ctx *ctx)
 {
 	LWGEOM *lwgeom = NULL;
 	bool isnull = false;
@@ -534,8 +563,9 @@ void flatgeobuf_agg_transfn(struct flatgeobuf_agg_ctx *ctx)
 		inspect_table(ctx);
 
 	datum = GetAttributeByNum(ctx->row, ctx->geom_index + 1, &isnull);
-	if (!isnull) {
-		gs = (GSERIALIZED *) PG_DETOAST_DATUM_COPY(datum);
+	if (!isnull)
+	{
+		gs = (GSERIALIZED *)PG_DETOAST_DATUM_COPY(datum);
 		lwgeom = lwgeom_from_gserialized(gs);
 	}
 	ctx->ctx->lwgeom = lwgeom;
@@ -554,15 +584,19 @@ void flatgeobuf_agg_transfn(struct flatgeobuf_agg_ctx *ctx)
  *
  * Encode into Data message and return it packed as a bytea.
  */
-uint8_t *flatgeobuf_agg_finalfn(struct flatgeobuf_agg_ctx *ctx)
+uint8_t *
+flatgeobuf_agg_finalfn(struct flatgeobuf_agg_ctx *ctx)
 {
 	POSTGIS_DEBUGF(3, "called at offset %lld", ctx->ctx->offset);
 	if (ctx == NULL)
 		flatgeobuf_agg_ctx_init(NULL, false);
 	// header only result
-	if (ctx->ctx->features_count == 0) {
+	if (ctx->ctx->features_count == 0)
+	{
 		flatgeobuf_encode_header(ctx->ctx);
-	} else if (ctx->ctx->create_index) {
+	}
+	else if (ctx->ctx->create_index)
+	{
 		ctx->ctx->index_node_size = 16;
 		flatgeobuf_create_index(ctx->ctx);
 	}

--- a/postgis/gserialized_estimate.c
+++ b/postgis/gserialized_estimate.c
@@ -1009,13 +1009,19 @@ estimate_join_selectivity(const ND_STATS *s1, const ND_STATS *s2)
 		POSTGIS_DEBUGF(3, "at1 %d,%d  %s", at1[0], at1[1], nd_box_to_json(&nd_cell1, ndims1));
 
 		/* Get the value at this cell */
-		val1 = s1->value[nd_stats_value_index(s1, at1)];
+		{
+			int vdx1 = nd_stats_value_index(s1, at1);
+			if (vdx1 < 0)
+				continue;
+			val1 = s1->value[vdx1];
+		}
 
 		/* For each overlapped cell of s2... */
 		do
 		{
 			double ratio2;
 			double val2;
+			int vdx2;
 
 			/* Construct the bounds of this cell */
 			ND_BOX nd_cell2;
@@ -1032,7 +1038,10 @@ estimate_join_selectivity(const ND_STATS *s1, const ND_STATS *s2)
 			ratio2 = nd_box_ratio(&nd_cell1, &nd_cell2, Max(ndims1, ndims2));
 
 			/* Multiply the cell counts, scaled by overlap ratio */
-			val2 = s2->value[nd_stats_value_index(s2, at2)];
+			vdx2 = nd_stats_value_index(s2, at2);
+			if (vdx2 < 0)
+				continue;
+			val2 = s2->value[vdx2];
 			POSTGIS_DEBUGF(3, "  val1 %.6g  val2 %.6g  ratio %.6g", val1, val2, ratio2);
 			val += val1 * (val2 * ratio2);
 		}
@@ -1617,7 +1626,11 @@ compute_gserialized_stats_mode(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfu
 			 * 0.5 added on.
 			 */
 			ratio = nd_box_ratio(&nd_cell, nd_box, nd_stats->ndims);
-			nd_stats->value[nd_stats_value_index(nd_stats, at)] += ratio;
+			{
+				int vdx = nd_stats_value_index(nd_stats, at);
+				if (vdx < 0) continue;
+				nd_stats->value[vdx] += ratio;
+			}
 			num_cells += ratio;
 			POSTGIS_DEBUGF(3, "               ratio (%.8g)  num_cells (%.8g)", ratio, num_cells);
 			POSTGIS_DEBUGF(3, "               at (%d, %d, %d, %d)", at[0], at[1], at[2], at[3]);
@@ -1876,7 +1889,11 @@ estimate_selectivity(const GBOX *box, const ND_STATS *nd_stats, int mode)
 		}
 
 		ratio = nd_box_ratio(&nd_box, &nd_cell, nd_stats->ndims);
-		cell_count = nd_stats->value[nd_stats_value_index(nd_stats, at)];
+		{
+			int vdx = nd_stats_value_index(nd_stats, at);
+			if (vdx < 0) continue;
+			cell_count = nd_stats->value[vdx];
+		}
 
 		/* Add the pro-rated count for this cell to the overall total */
 		total_count += (double)cell_count * ratio;

--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -858,7 +858,10 @@ static int
 copy_from_end(STRINGBUFFER *buffer)
 {
 	/* end of data */
-	append_sql_to_buffer(buffer, strdup("\\."));
+	char *str = strdup("\\.");
+	if (str == NULL)
+		return 0;
+	append_sql_to_buffer(buffer, str);
 
 	return 1;
 }


### PR DESCRIPTION
## Summary

Implements **sonarcloud-cleanup Phase 3a** (memory-safety fixes) and salvages one commit from closed PR #8.

### Real bug fixes (NULL dereferences, SonarCloud S2259)

- **`postgis/flatgeobuf.c`** — `flatgeobuf_agg_finalfn()` dereferenced `ctx->ctx->offset` in a `POSTGIS_DEBUGF` call *before* the NULL check on `ctx`. Even the fallback `flatgeobuf_agg_ctx_init(NULL, false)` return value was discarded, so a successful init could not rescue the subsequent accesses. Fixed by reordering and capturing the return value.
- **`liblwgeom/optionlist.c`** — `option_list_parse()` called `lwerror()` on missing separator but did not return; execution fell through to `*val = '\0'` where `val` was `NULL`. Fixed by adding explicit `return;` after `lwerror()` (matches the pattern already used in `option_list_gdal_parse` for the same error).

### Salvaged from closed PR #8 (commit `47c20c68d`)

- **`postgis/gserialized_estimate.c`** — guard `nd_stats_value_index()` callers against the documented `-1` return (4 call sites previously used as unchecked array indices).
- **`raster/loader/raster2pgsql.c`** — NULL check after `strdup()` in `copy_from_end()` before passing to `append_sql_to_buffer()`.

### Regression coverage

Extends `cu_misc.c::test_optionlist` with a malformed-input case that previously never exercised the error path.

## Commit structure

```
7dc645e2e  Fix NULL pointer dereferences flagged by SonarCloud S2259   (logic)
7b79a99c7  Style-only: reformat cu_misc.c to match .clang-format        (style)
673c4c7bb  Style-only: reformat optionlist.c to match .clang-format     (style)
849ed0079  Style-only: reformat flatgeobuf.c to match .clang-format     (style)
8de2429ef  Fix BLOCKER bugs: guard against negative index and NULL strdup  (cherry-pick of 47c20c68d)
```

Style-only commits are separated from logic per project convention (CLAUDE.md). The three files had pre-existing `.clang-format` violations that the pre-commit hook flagged once any line was touched.

## Category

**UPSTREAM_READY** per the four-way classification in `upstream-postgis-contribution-roadmap`. The two NULL derefs and the gserialized_estimate/raster2pgsql guards are genuine memory-safety bugs that upstream `postgis/postgis` would benefit from. Upstream PR to be spawned via `upstream-postgis-contribution-roadmap` Phase 2 after this lands on fork develop.

## Test plan

- [ ] Full CI matrix passes (ASan, USan, mingw, latest, pg14-18, SonarCloud Scan)
- [ ] `cu_misc` CUnit suite passes including new `test_optionlist` malformed-input case
- [ ] SonarCloud reports S2259 count decrease (2 → 0 for these sites)
- [ ] SonarCloud blocker count decrease after `47c20c68d` lands

## References

- Phase 3a tasks: `openspec/changes/sonarcloud-cleanup/tasks.md` (3a.1–3a.6, 3d.1)
- Upstream roadmap: `openspec/changes/upstream-postgis-contribution-roadmap/tasks.md` (Phase 2)
- Closed PR #8 salvage audit: confirmed only `47c20c68d` applies cleanly; `c133a2cfb` already fixed on develop with `= 0`; `8df75747a` partially already in via `bfbd98209`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)