### PR TITLE
SonarCloud Phase 4: replace strtok with strtok_r for thread safety

### DIFF
--- a/liblwgeom/optionlist.c
+++ b/liblwgeom/optionlist.c
@@ -97,12 +97,13 @@ option_list_parse(char *input, char **olist)
 	const char *toksep = " ";
 	const char kvsep = '=';
 	char *key, *val;
+	char *saveptr = NULL;
 	if (!input)
 		return;
 	size_t i = 0, sz;
 
-	/* strtok nulls out the space between each token */
-	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep))
+	/* strtok_r nulls out the space between each token */
+	for (key = strtok_r(input, toksep, &saveptr); key; key = strtok_r(NULL, toksep, &saveptr))
 	{
 		if (i >= OPTION_LIST_SIZE)
 			return;
@@ -143,6 +144,7 @@ option_list_gdal_parse(char *input, char **olist)
 	const char notspace = 0x1F;
 
 	char *key, *val;
+	char *saveptr = NULL;
 	int in_str = 0;
 	size_t i = 0, sz, input_sz;
 	char *ptr = input;
@@ -163,7 +165,7 @@ option_list_gdal_parse(char *input, char **olist)
 	}
 
 	/* Tokenize on spaces */
-	for (key = strtok(input, toksep); key; key = strtok(NULL, toksep))
+	for (key = strtok_r(input, toksep, &saveptr); key; key = strtok_r(NULL, toksep, &saveptr))
 	{
 		if (i >= OPTION_LIST_SIZE)
 			return;

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -1045,12 +1045,13 @@ buffer(PG_FUNCTION_ARGS)
 	if (VARSIZE_ANY_EXHDR(params_text) > 0)
 	{
 		char *param;
+		char *saveptr = NULL;
 		char *params = text_to_cstring(params_text);
 
 		for (param = params;; param = NULL)
 		{
 			char *key, *val;
-			param = strtok(param, " ");
+			param = strtok_r(param, " ", &saveptr);
 			if (!param)
 				break;
 			POSTGIS_DEBUGF(3, "Param: %s", param);
@@ -1288,6 +1289,7 @@ ST_OffsetCurve(PG_FUNCTION_ARGS)
 	int joinStyle = DEFAULT_JOIN_STYLE;
 	char *param = NULL;
 	char *paramstr = NULL;
+	char *saveptr = NULL;
 
 	/* Read SQL arguments */
 	nargs = PG_NARGS();
@@ -1319,7 +1321,7 @@ ST_OffsetCurve(PG_FUNCTION_ARGS)
 		for (param = paramstr;; param = NULL)
 		{
 			char *key, *val;
-			param = strtok(param, " ");
+			param = strtok_r(param, " ", &saveptr);
 			if (!param)
 				break;
 			POSTGIS_DEBUGF(3, "Param: %s", param);

--- a/postgis/lwgeom_geos.c
+++ b/postgis/lwgeom_geos.c
@@ -24,7 +24,6 @@
  *
  **********************************************************************/
 
-
 #include "../postgis_config.h"
 
 /* PostgreSQL */
@@ -44,9 +43,6 @@
 #include "lwgeom_itree.h"
 #include "lwgeom_geos_prepared.h"
 #include "lwgeom_accum.h"
-
-
-
 
 /*
 ** Prototypes for SQL-bound functions
@@ -90,19 +86,21 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS);
 */
 
 PG_FUNCTION_INFO_V1(postgis_geos_version);
-Datum postgis_geos_version(PG_FUNCTION_ARGS)
+Datum
+postgis_geos_version(PG_FUNCTION_ARGS)
 {
-    const char *ver = lwgeom_geos_version();
-    text *result = cstring_to_text(ver);
-    PG_RETURN_POINTER(result);
+	const char *ver = lwgeom_geos_version();
+	text *result = cstring_to_text(ver);
+	PG_RETURN_POINTER(result);
 }
 
 PG_FUNCTION_INFO_V1(postgis_geos_compiled_version);
-Datum postgis_geos_compiled_version(PG_FUNCTION_ARGS)
+Datum
+postgis_geos_compiled_version(PG_FUNCTION_ARGS)
 {
-    const char *ver = lwgeom_geos_compiled_version();
-    text *result = cstring_to_text(ver);
-    PG_RETURN_POINTER(result);
+	const char *ver = lwgeom_geos_compiled_version();
+	text *result = cstring_to_text(ver);
+	PG_RETURN_POINTER(result);
 }
 
 /**
@@ -112,7 +110,8 @@ Datum postgis_geos_compiled_version(PG_FUNCTION_ARGS)
  *      'POLYGON((0.5 0.5, 0.5 2.5, 1.5 2.5, 2.5 2.5, 2.5 0.5, 0.5 0.5))'::geometry);
  */
 PG_FUNCTION_INFO_V1(hausdorffdistance);
-Datum hausdorffdistance(PG_FUNCTION_ARGS)
+Datum
+hausdorffdistance(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -124,7 +123,7 @@ Datum hausdorffdistance(PG_FUNCTION_ARGS)
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
 
-	if ( gserialized_is_empty(geom1) || gserialized_is_empty(geom2) )
+	if (gserialized_is_empty(geom1) || gserialized_is_empty(geom2))
 		PG_RETURN_NULL();
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -144,7 +143,8 @@ Datum hausdorffdistance(PG_FUNCTION_ARGS)
 	GEOSGeom_destroy(g1);
 	GEOSGeom_destroy(g2);
 
-	if (retcode == 0) HANDLE_GEOS_ERROR("GEOSHausdorffDistance");
+	if (retcode == 0)
+		HANDLE_GEOS_ERROR("GEOSHausdorffDistance");
 
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);
@@ -161,7 +161,8 @@ Datum hausdorffdistance(PG_FUNCTION_ARGS)
  */
 
 PG_FUNCTION_INFO_V1(hausdorffdistancedensify);
-Datum hausdorffdistancedensify(PG_FUNCTION_ARGS)
+Datum
+hausdorffdistancedensify(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -175,7 +176,7 @@ Datum hausdorffdistancedensify(PG_FUNCTION_ARGS)
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
 	densifyFrac = PG_GETARG_FLOAT8(2);
 
-	if ( gserialized_is_empty(geom1) || gserialized_is_empty(geom2) )
+	if (gserialized_is_empty(geom1) || gserialized_is_empty(geom2))
 		PG_RETURN_NULL();
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -195,7 +196,8 @@ Datum hausdorffdistancedensify(PG_FUNCTION_ARGS)
 	GEOSGeom_destroy(g1);
 	GEOSGeom_destroy(g2);
 
-	if (retcode == 0) HANDLE_GEOS_ERROR("GEOSHausdorffDistanceDensify");
+	if (retcode == 0)
+		HANDLE_GEOS_ERROR("GEOSHausdorffDistanceDensify");
 
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);
@@ -211,7 +213,8 @@ Datum hausdorffdistancedensify(PG_FUNCTION_ARGS)
  */
 
 PG_FUNCTION_INFO_V1(ST_FrechetDistance);
-Datum ST_FrechetDistance(PG_FUNCTION_ARGS)
+Datum
+ST_FrechetDistance(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -225,7 +228,7 @@ Datum ST_FrechetDistance(PG_FUNCTION_ARGS)
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
 	densifyFrac = PG_GETARG_FLOAT8(2);
 
-	if ( gserialized_is_empty(geom1) || gserialized_is_empty(geom2) )
+	if (gserialized_is_empty(geom1) || gserialized_is_empty(geom2))
 		PG_RETURN_NULL();
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -253,7 +256,8 @@ Datum ST_FrechetDistance(PG_FUNCTION_ARGS)
 	GEOSGeom_destroy(g1);
 	GEOSGeom_destroy(g2);
 
-	if (retcode == 0) HANDLE_GEOS_ERROR("GEOSFrechetDistance");
+	if (retcode == 0)
+		HANDLE_GEOS_ERROR("GEOSFrechetDistance");
 
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);
@@ -261,14 +265,13 @@ Datum ST_FrechetDistance(PG_FUNCTION_ARGS)
 	PG_RETURN_FLOAT8(result);
 }
 
-
-
 PG_FUNCTION_INFO_V1(ST_MaximumInscribedCircle);
-Datum ST_MaximumInscribedCircle(PG_FUNCTION_ARGS)
+Datum
+ST_MaximumInscribedCircle(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* geom;
-	GSERIALIZED* center;
-	GSERIALIZED* nearest;
+	GSERIALIZED *geom;
+	GSERIALIZED *center;
+	GSERIALIZED *nearest;
 	TupleDesc resultTupleDesc;
 	HeapTuple resultTuple;
 	Datum result;
@@ -285,11 +288,11 @@ Datum ST_MaximumInscribedCircle(PG_FUNCTION_ARGS)
 	srid = gserialized_get_srid(geom);
 	is3d = gserialized_has_z(geom);
 
-    /* Empty geometry?  Return POINT EMPTY with zero radius */
+	/* Empty geometry?  Return POINT EMPTY with zero radius */
 	if (gserialized_is_empty(geom))
 	{
-		LWGEOM* lwcenter = (LWGEOM*) lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
-		LWGEOM* lwnearest = (LWGEOM*) lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
+		LWGEOM *lwcenter = (LWGEOM *)lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
+		LWGEOM *lwnearest = (LWGEOM *)lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
 		center = geometry_serialize(lwcenter);
 		nearest = geometry_serialize(lwnearest);
 		radius = 0.0;
@@ -375,15 +378,15 @@ Datum ST_MaximumInscribedCircle(PG_FUNCTION_ARGS)
 	PG_RETURN_DATUM(result);
 }
 
-
 /* ST_LargestEmptyCircle(geom, boundary, tolerance) */
 PG_FUNCTION_INFO_V1(ST_LargestEmptyCircle);
-Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
+Datum
+ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* geom;
-	GSERIALIZED* boundary;
-	GSERIALIZED* center;
-	GSERIALIZED* nearest;
+	GSERIALIZED *geom;
+	GSERIALIZED *boundary;
+	GSERIALIZED *center;
+	GSERIALIZED *nearest;
 	TupleDesc resultTupleDesc;
 	HeapTuple resultTuple;
 	Datum result;
@@ -402,14 +405,14 @@ Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
 	srid = gserialized_get_srid(geom);
 	is3d = gserialized_has_z(geom);
 
-	if (boundary && ! gserialized_is_empty(boundary))
+	if (boundary && !gserialized_is_empty(boundary))
 		hasBoundary = true;
 
-    /* Empty geometry?  Return POINT EMPTY with zero radius */
+	/* Empty geometry?  Return POINT EMPTY with zero radius */
 	if (gserialized_is_empty(geom))
 	{
-		LWGEOM* lwcenter = (LWGEOM*) lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
-		LWGEOM* lwnearest = (LWGEOM*) lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
+		LWGEOM *lwcenter = (LWGEOM *)lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
+		LWGEOM *lwnearest = (LWGEOM *)lwpoint_construct_empty(gserialized_get_srid(geom), LW_FALSE, LW_FALSE);
 		center = geometry_serialize(lwcenter);
 		nearest = geometry_serialize(lwnearest);
 		radius = 0.0;
@@ -428,7 +431,6 @@ Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
 			PG_RETURN_NULL();
 		}
 		lwgeom_free(lwg);
-
 
 		if (!gserialized_get_gbox_p(geom, &gbox))
 			PG_RETURN_NULL();
@@ -474,7 +476,8 @@ Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
 		GEOSGeom_destroy(gnearest);
 		GEOSGeom_destroy(gcircle);
 		GEOSGeom_destroy(ginput);
-		if (gboundary) GEOSGeom_destroy(gboundary);
+		if (gboundary)
+			GEOSGeom_destroy(gboundary);
 	}
 
 	get_call_result_type(fcinfo, NULL, &resultTupleDesc);
@@ -493,8 +496,6 @@ Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
 	PG_RETURN_DATUM(result);
 }
 
-
-
 /**
  * @brief This is the final function for GeomUnion
  * 			aggregate. Will have as input an array of Geometries.
@@ -503,7 +504,8 @@ Datum ST_LargestEmptyCircle(PG_FUNCTION_ARGS)
  * 			Changing combination order *might* speed up performance.
  */
 PG_FUNCTION_INFO_V1(pgis_union_geometry_array);
-Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
+Datum
+pgis_union_geometry_array(PG_FUNCTION_ARGS)
 {
 	ArrayType *array;
 
@@ -525,35 +527,36 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	int empty_type = 0;
 
 	/* Null array, null geometry (should be empty?) */
-	if ( PG_ARGISNULL(0) )
+	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
 
 	array = PG_GETARG_ARRAYTYPE_P(0);
 	nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
 
 	/* Empty array? Null return */
-	if ( nelems == 0 ) PG_RETURN_NULL();
+	if (nelems == 0)
+		PG_RETURN_NULL();
 
 	/* Quick scan for nulls */
 	iterator = array_create_iterator(array, 0, NULL);
 	while (array_iterate(iterator, &value, &isnull))
 	{
 		/* Skip null array items */
-		if (isnull) continue;
+		if (isnull)
+			continue;
 		count++;
 	}
 	array_free_iterator(iterator);
 
-
 	/* All-nulls? Return null */
-	if ( count == 0 )
+	if (count == 0)
 		PG_RETURN_NULL();
 
 	/* Ok, we really need GEOS now ;) */
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
 	/* One geom, good geom? Return it */
-	if ( count == 1 && nelems == 1 )
+	if (count == 1 && nelems == 1)
 	{
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
@@ -566,7 +569,8 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 		srid = GEOSGetSRID(g);
 		g_union = GEOSUnaryUnion(g);
 		GEOSGeom_destroy(g);
-		if (!g_union) HANDLE_GEOS_ERROR("GEOSUnaryUnion");
+		if (!g_union)
+			HANDLE_GEOS_ERROR("GEOSUnaryUnion");
 		GEOSSetSRID(g_union, srid);
 		gser_out = GEOS2POSTGIS(g_union, is3d);
 		GEOSGeom_destroy(g_union);
@@ -577,7 +581,7 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	** Collect the non-empty inputs and stuff them into a GEOS collection
 	*/
 	geoms_size = nelems;
-	geoms = palloc(sizeof(GEOSGeometry*) * geoms_size);
+	geoms = palloc(sizeof(GEOSGeometry *) * geoms_size);
 
 	/*
 	** We need to convert the array of GSERIALIZED into a GEOS collection.
@@ -589,11 +593,12 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 		GSERIALIZED *gser_in;
 
 		/* Skip null array items */
-		if (isnull) continue;
+		if (isnull)
+			continue;
 		gser_in = (GSERIALIZED *)DatumGetPointer(value);
 
 		/* Check for SRID mismatch in array elements */
-		if ( gotsrid )
+		if (gotsrid)
 			gserialized_error_if_srid_mismatch_reference(gser_in, srid, __func__);
 		else
 		{
@@ -604,7 +609,7 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 		}
 
 		/* Don't include empties in the union */
-		if ( gserialized_is_empty(gser_in) )
+		if (gserialized_is_empty(gser_in))
 		{
 			int gser_type = gserialized_get_type(gser_in);
 			if (gser_type > empty_type)
@@ -618,7 +623,7 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 			g = POSTGIS2GEOS(gser_in);
 
 			/* Uh oh! Exception thrown at construction... */
-			if ( ! g )
+			if (!g)
 			{
 				HANDLE_GEOS_ERROR(
 				    "One of the geometries in the set "
@@ -626,16 +631,15 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 			}
 
 			/* Ensure we have enough space in our storage array */
-			if ( curgeom == geoms_size )
+			if (curgeom == geoms_size)
 			{
 				geoms_size *= 2;
-				geoms = repalloc( geoms, sizeof(GEOSGeometry*) * geoms_size );
+				geoms = repalloc(geoms, sizeof(GEOSGeometry *) * geoms_size);
 			}
 
 			geoms[curgeom] = g;
 			curgeom++;
 		}
-
 	}
 	array_free_iterator(iterator);
 
@@ -646,11 +650,13 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	if (curgeom > 0)
 	{
 		g = GEOSGeom_createCollection(GEOS_GEOMETRYCOLLECTION, geoms, curgeom);
-		if (!g) HANDLE_GEOS_ERROR("Could not create GEOS COLLECTION from geometry array");
+		if (!g)
+			HANDLE_GEOS_ERROR("Could not create GEOS COLLECTION from geometry array");
 
 		g_union = GEOSUnaryUnion(g);
 		GEOSGeom_destroy(g);
-		if (!g_union) HANDLE_GEOS_ERROR("GEOSUnaryUnion");
+		if (!g_union)
+			HANDLE_GEOS_ERROR("GEOSUnaryUnion");
 
 		GEOSSetSRID(g_union, srid);
 		gser_out = GEOS2POSTGIS(g_union, is3d);
@@ -660,7 +666,7 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	else
 	{
 		/* If it was only empties, we'll return the largest type number */
-		if ( empty_type > 0 )
+		if (empty_type > 0)
 		{
 			PG_RETURN_POINTER(geometry_serialize(lwgeom_construct_empty(empty_type, srid, is3d, 0)));
 		}
@@ -671,7 +677,7 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 		}
 	}
 
-	if ( ! gser_out )
+	if (!gser_out)
 	{
 		/* Union returned a NULL geometry */
 		PG_RETURN_NULL();
@@ -680,7 +686,6 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(gser_out);
 }
 
-
 /**
  * @example ST_UnaryUnion {@link #geomunion} SELECT ST_UnaryUnion(
  *      'POLYGON((0 0, 10 0, 0 10, 10 10, 0 0))'
@@ -688,24 +693,25 @@ Datum pgis_union_geometry_array(PG_FUNCTION_ARGS)
  *
  */
 PG_FUNCTION_INFO_V1(ST_UnaryUnion);
-Datum ST_UnaryUnion(PG_FUNCTION_ARGS)
+Datum
+ST_UnaryUnion(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *result;
-	LWGEOM *lwgeom1, *lwresult ;
+	LWGEOM *lwgeom1, *lwresult;
 	double prec = -1;
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
-	if (PG_NARGS() > 1 && ! PG_ARGISNULL(1))
+	if (PG_NARGS() > 1 && !PG_ARGISNULL(1))
 		prec = PG_GETARG_FLOAT8(1);
 
-	lwgeom1 = lwgeom_from_gserialized(geom1) ;
+	lwgeom1 = lwgeom_from_gserialized(geom1);
 
 	lwresult = lwgeom_unaryunion_prec(lwgeom1, prec);
-	result = geometry_serialize(lwresult) ;
+	result = geometry_serialize(lwresult);
 
-	lwgeom_free(lwgeom1) ;
-	lwgeom_free(lwresult) ;
+	lwgeom_free(lwgeom1);
+	lwgeom_free(lwresult);
 
 	PG_FREE_IF_COPY(geom1, 0);
 
@@ -713,7 +719,8 @@ Datum ST_UnaryUnion(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(ST_Union);
-Datum ST_Union(PG_FUNCTION_ARGS)
+Datum
+ST_Union(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -723,7 +730,7 @@ Datum ST_Union(PG_FUNCTION_ARGS)
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
-	if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 		gridSize = PG_GETARG_FLOAT8(2);
 
 	lwgeom1 = lwgeom_from_gserialized(geom1);
@@ -748,28 +755,29 @@ Datum ST_Union(PG_FUNCTION_ARGS)
  *      'POLYGON((5 5, 15 5, 15 7, 5 7, 5 5))');
  */
 PG_FUNCTION_INFO_V1(ST_SymDifference);
-Datum ST_SymDifference(PG_FUNCTION_ARGS)
+Datum
+ST_SymDifference(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
 	GSERIALIZED *result;
-	LWGEOM *lwgeom1, *lwgeom2, *lwresult ;
+	LWGEOM *lwgeom1, *lwgeom2, *lwresult;
 	double prec = -1;
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
-	if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 		prec = PG_GETARG_FLOAT8(2);
 
-	lwgeom1 = lwgeom_from_gserialized(geom1) ;
-	lwgeom2 = lwgeom_from_gserialized(geom2) ;
+	lwgeom1 = lwgeom_from_gserialized(geom1);
+	lwgeom2 = lwgeom_from_gserialized(geom2);
 
 	lwresult = lwgeom_symdifference_prec(lwgeom1, lwgeom2, prec);
-	result = geometry_serialize(lwresult) ;
+	result = geometry_serialize(lwresult);
 
-	lwgeom_free(lwgeom1) ;
-	lwgeom_free(lwgeom2) ;
-	lwgeom_free(lwresult) ;
+	lwgeom_free(lwgeom1);
+	lwgeom_free(lwgeom2);
+	lwgeom_free(lwresult);
 
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);
@@ -778,7 +786,8 @@ Datum ST_SymDifference(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(convexhull);
-Datum convexhull(PG_FUNCTION_ARGS)
+Datum
+convexhull(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GEOSGeometry *g1, *g3;
@@ -792,7 +801,7 @@ Datum convexhull(PG_FUNCTION_ARGS)
 	gserialized_check_crs_family_not_geocentric(geom1, "ST_ConvexHull");
 
 	/* Empty.ConvexHull() == Empty */
-	if ( gserialized_is_empty(geom1) )
+	if (gserialized_is_empty(geom1))
 		PG_RETURN_POINTER(geom1);
 
 	srid = gserialized_get_srid(geom1);
@@ -807,7 +816,8 @@ Datum convexhull(PG_FUNCTION_ARGS)
 	g3 = GEOSConvexHull(g1);
 	GEOSGeom_destroy(g1);
 
-	if (!g3) HANDLE_GEOS_ERROR("GEOSConvexHull");
+	if (!g3)
+		HANDLE_GEOS_ERROR("GEOSConvexHull");
 
 	POSTGIS_DEBUGF(3, "result: %s", GEOSGeomToWKT(g3));
 
@@ -818,13 +828,12 @@ Datum convexhull(PG_FUNCTION_ARGS)
 
 	if (!lwout)
 	{
-		elog(ERROR,
-		     "convexhull() failed to convert GEOS geometry to LWGEOM");
+		elog(ERROR, "convexhull() failed to convert GEOS geometry to LWGEOM");
 		PG_RETURN_NULL(); /* never get here */
 	}
 
 	/* Copy input bbox if any */
-	if ( gserialized_get_gbox_p(geom1, &bbox) )
+	if (gserialized_get_gbox_p(geom1, &bbox))
 	{
 		/* Force the box to have the same dimensionality as the lwgeom */
 		bbox.flags = lwout->flags;
@@ -836,7 +845,7 @@ Datum convexhull(PG_FUNCTION_ARGS)
 
 	if (!result)
 	{
-		elog(ERROR,"GEOS convexhull() threw an error (result postgis geometry formation)!");
+		elog(ERROR, "GEOS convexhull() threw an error (result postgis geometry formation)!");
 		PG_RETURN_NULL(); /* never get here */
 	}
 
@@ -844,26 +853,27 @@ Datum convexhull(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
-
 PG_FUNCTION_INFO_V1(ST_ConcaveHull);
-Datum ST_ConcaveHull(PG_FUNCTION_ARGS)
+Datum
+ST_ConcaveHull(PG_FUNCTION_ARGS)
 {
 #if POSTGIS_GEOS_VERSION < 31100
 
-	lwpgerror("The GEOS version this PostGIS binary "
-				"was compiled against (%d) doesn't support "
-				"'GEOSConcaveHull' function (3.11.0+ required)",
-				POSTGIS_GEOS_VERSION);
+	lwpgerror(
+	    "The GEOS version this PostGIS binary "
+	    "was compiled against (%d) doesn't support "
+	    "'GEOSConcaveHull' function (3.11.0+ required)",
+	    POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
 
 #else /* POSTGIS_GEOS_VERSION >= 31100 */
-	GSERIALIZED* geom = PG_GETARG_GSERIALIZED_P(0);
+	GSERIALIZED *geom = PG_GETARG_GSERIALIZED_P(0);
 	double ratio = PG_GETARG_FLOAT8(1);
 	bool allow_holes = PG_GETARG_BOOL(2);
 
-	LWGEOM* lwgeom = lwgeom_from_gserialized(geom);
-	LWGEOM* lwresult = lwgeom_concavehull(lwgeom, ratio, allow_holes);
-	GSERIALIZED* result = geometry_serialize(lwresult);
+	LWGEOM *lwgeom = lwgeom_from_gserialized(geom);
+	LWGEOM *lwresult = lwgeom_concavehull(lwgeom, ratio, allow_holes);
+	GSERIALIZED *result = geometry_serialize(lwresult);
 
 	lwgeom_free(lwgeom);
 	lwgeom_free(lwresult);
@@ -872,25 +882,26 @@ Datum ST_ConcaveHull(PG_FUNCTION_ARGS)
 #endif
 }
 
-
 PG_FUNCTION_INFO_V1(ST_SimplifyPolygonHull);
-Datum ST_SimplifyPolygonHull(PG_FUNCTION_ARGS)
+Datum
+ST_SimplifyPolygonHull(PG_FUNCTION_ARGS)
 {
 #if POSTGIS_GEOS_VERSION < 31100
 
-	lwpgerror("The GEOS version this PostGIS binary "
-				"was compiled against (%d) doesn't support "
-				"'ST_SimplifyPolygonHull' function (3.11.0+ required)",
-				POSTGIS_GEOS_VERSION);
+	lwpgerror(
+	    "The GEOS version this PostGIS binary "
+	    "was compiled against (%d) doesn't support "
+	    "'ST_SimplifyPolygonHull' function (3.11.0+ required)",
+	    POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
 
 #else /* POSTGIS_GEOS_VERSION >= 31100 */
-	GSERIALIZED* geom = PG_GETARG_GSERIALIZED_P(0);
+	GSERIALIZED *geom = PG_GETARG_GSERIALIZED_P(0);
 	double vertex_fraction = PG_GETARG_FLOAT8(1);
 	uint32_t is_outer = PG_GETARG_BOOL(2);
-	LWGEOM* lwgeom;
-	LWGEOM* lwresult;
-	GSERIALIZED* result;
+	LWGEOM *lwgeom;
+	LWGEOM *lwresult;
+	GSERIALIZED *result;
 
 	gserialized_check_crs_family_not_geocentric(geom, "ST_SimplifyPolygonHull");
 
@@ -905,13 +916,13 @@ Datum ST_SimplifyPolygonHull(PG_FUNCTION_ARGS)
 #endif
 }
 
-
 PG_FUNCTION_INFO_V1(topologypreservesimplify);
-Datum topologypreservesimplify(PG_FUNCTION_ARGS)
+Datum
+topologypreservesimplify(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED	*gs1;
+	GSERIALIZED *gs1;
 	LWGEOM *lwg1;
-	double	tolerance;
+	double tolerance;
 	GEOSGeometry *g1, *g3;
 	GSERIALIZED *result;
 	uint32_t type;
@@ -941,10 +952,11 @@ Datum topologypreservesimplify(PG_FUNCTION_ARGS)
 	if (!g1)
 		HANDLE_GEOS_ERROR("First argument geometry could not be converted to GEOS");
 
-	g3 = GEOSTopologyPreserveSimplify(g1,tolerance);
+	g3 = GEOSTopologyPreserveSimplify(g1, tolerance);
 	GEOSGeom_destroy(g1);
 
-	if (!g3) HANDLE_GEOS_ERROR("GEOSTopologyPreserveSimplify");
+	if (!g3)
+		HANDLE_GEOS_ERROR("GEOSTopologyPreserveSimplify");
 
 	POSTGIS_DEBUGF(3, "result: %s", GEOSGeomToWKT(g3));
 
@@ -955,7 +967,7 @@ Datum topologypreservesimplify(PG_FUNCTION_ARGS)
 
 	if (!result)
 	{
-		elog(ERROR,"GEOS topologypreservesimplify() threw an error (result postgis geometry formation)!");
+		elog(ERROR, "GEOS topologypreservesimplify() threw an error (result postgis geometry formation)!");
 		PG_RETURN_NULL(); /* never get here */
 	}
 
@@ -964,34 +976,35 @@ Datum topologypreservesimplify(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(buffer);
-Datum buffer(PG_FUNCTION_ARGS)
+Datum
+buffer(PG_FUNCTION_ARGS)
 {
 	GEOSBufferParams *bufferparams;
 	GEOSGeometry *g1, *g3 = NULL;
 	GSERIALIZED *result;
 	LWGEOM *lwg;
-	int quadsegs = 8; /* the default */
+	int quadsegs = 8;   /* the default */
 	int singleside = 0; /* the default */
 	enum
 	{
-	    ENDCAP_ROUND = 1,
-	    ENDCAP_FLAT = 2,
-	    ENDCAP_SQUARE = 3
+		ENDCAP_ROUND = 1,
+		ENDCAP_FLAT = 2,
+		ENDCAP_SQUARE = 3
 	};
 	enum
 	{
-	    JOIN_ROUND = 1,
-	    JOIN_MITRE = 2,
-	    JOIN_BEVEL = 3
+		JOIN_ROUND = 1,
+		JOIN_MITRE = 2,
+		JOIN_BEVEL = 3
 	};
 	const double DEFAULT_MITRE_LIMIT = 5.0;
 	const int DEFAULT_ENDCAP_STYLE = ENDCAP_ROUND;
 	const int DEFAULT_JOIN_STYLE = JOIN_ROUND;
 	double mitreLimit = DEFAULT_MITRE_LIMIT;
 	int endCapStyle = DEFAULT_ENDCAP_STYLE;
-	int joinStyle  = DEFAULT_JOIN_STYLE;
+	int joinStyle = DEFAULT_JOIN_STYLE;
 
-	GSERIALIZED	*geom1 = PG_GETARG_GSERIALIZED_P(0);
+	GSERIALIZED *geom1 = PG_GETARG_GSERIALIZED_P(0);
 	double size = PG_GETARG_FLOAT8(1);
 	text *params_text;
 
@@ -1007,11 +1020,10 @@ Datum buffer(PG_FUNCTION_ARGS)
 	}
 
 	/* Empty.Buffer() == Empty[polygon] */
-	if ( gserialized_is_empty(geom1) )
+	if (gserialized_is_empty(geom1))
 	{
 		lwg = lwpoly_as_lwgeom(lwpoly_construct_empty(
-		        gserialized_get_srid(geom1),
-		        0, 0)); // buffer wouldn't give back z or m anyway
+		    gserialized_get_srid(geom1), 0, 0)); // buffer wouldn't give back z or m anyway
 		PG_RETURN_POINTER(geometry_serialize(lwg));
 	}
 
@@ -1030,17 +1042,17 @@ Datum buffer(PG_FUNCTION_ARGS)
 	if (!g1)
 		HANDLE_GEOS_ERROR("First argument geometry could not be converted to GEOS");
 
-
 	if (VARSIZE_ANY_EXHDR(params_text) > 0)
 	{
 		char *param;
 		char *params = text_to_cstring(params_text);
 
-		for (param=params; ; param=NULL)
+		for (param = params;; param = NULL)
 		{
 			char *key, *val;
 			param = strtok(param, " ");
-			if (!param) break;
+			if (!param)
+				break;
 			POSTGIS_DEBUGF(3, "Param: %s", param);
 
 			key = param;
@@ -1055,82 +1067,82 @@ Datum buffer(PG_FUNCTION_ARGS)
 
 			POSTGIS_DEBUGF(3, "Param: %s : %s", key, val);
 
-			if ( !strcmp(key, "endcap") )
+			if (!strcmp(key, "endcap"))
 			{
 				/* Supported end cap styles:
 				 *   "round", "flat", "square"
 				 */
-				if ( !strcmp(val, "round") )
+				if (!strcmp(val, "round"))
 				{
 					endCapStyle = ENDCAP_ROUND;
 				}
-				else if ( !strcmp(val, "flat") ||
-				          !strcmp(val, "butt")    )
+				else if (!strcmp(val, "flat") || !strcmp(val, "butt"))
 				{
 					endCapStyle = ENDCAP_FLAT;
 				}
-				else if ( !strcmp(val, "square") )
+				else if (!strcmp(val, "square"))
 				{
 					endCapStyle = ENDCAP_SQUARE;
 				}
 				else
 				{
-					lwpgerror("Invalid buffer end cap "
-					        "style: %s (accept: "
-					        "'round', 'flat', 'butt' "
-					        "or 'square'"
-					        ")", val);
+					lwpgerror(
+					    "Invalid buffer end cap "
+					    "style: %s (accept: "
+					    "'round', 'flat', 'butt' "
+					    "or 'square'"
+					    ")",
+					    val);
 					break;
 				}
-
 			}
-			else if ( !strcmp(key, "join") )
+			else if (!strcmp(key, "join"))
 			{
-				if ( !strcmp(val, "round") )
+				if (!strcmp(val, "round"))
 				{
 					joinStyle = JOIN_ROUND;
 				}
-				else if ( !strcmp(val, "mitre") ||
-				          !strcmp(val, "miter")    )
+				else if (!strcmp(val, "mitre") || !strcmp(val, "miter"))
 				{
 					joinStyle = JOIN_MITRE;
 				}
-				else if ( !strcmp(val, "bevel") )
+				else if (!strcmp(val, "bevel"))
 				{
 					joinStyle = JOIN_BEVEL;
 				}
 				else
 				{
-					lwpgerror("Invalid buffer end cap "
-					        "style: %s (accept: "
-					        "'round', 'mitre', 'miter' "
-					        " or 'bevel'"
-					        ")", val);
+					lwpgerror(
+					    "Invalid buffer end cap "
+					    "style: %s (accept: "
+					    "'round', 'mitre', 'miter' "
+					    " or 'bevel'"
+					    ")",
+					    val);
 					break;
 				}
 			}
-			else if ( !strcmp(key, "mitre_limit") ||
-			          !strcmp(key, "miter_limit")    )
+			else if (!strcmp(key, "mitre_limit") || !strcmp(key, "miter_limit"))
 			{
 				/* mitreLimit is a float */
 				mitreLimit = atof(val);
 			}
-			else if ( !strcmp(key, "quad_segs") )
+			else if (!strcmp(key, "quad_segs"))
 			{
 				/* quadrant segments is an int */
 				quadsegs = atoi(val);
 			}
-			else if ( !strcmp(key, "side") )
+			else if (!strcmp(key, "side"))
 			{
-				if ( !strcmp(val, "both") )
+				if (!strcmp(val, "both"))
 				{
 					singleside = 0;
 				}
-				else if ( !strcmp(val, "left") )
+				else if (!strcmp(val, "left"))
 				{
 					singleside = 1;
 				}
-				else if ( !strcmp(val, "right") )
+				else if (!strcmp(val, "right"))
 				{
 					singleside = 1;
 					size *= -1;
@@ -1152,18 +1164,16 @@ Datum buffer(PG_FUNCTION_ARGS)
 		pfree(params); /* was pstrduped */
 	}
 
-
-	POSTGIS_DEBUGF(3, "endCap:%d joinStyle:%d mitreLimit:%g",
-	               endCapStyle, joinStyle, mitreLimit);
+	POSTGIS_DEBUGF(3, "endCap:%d joinStyle:%d mitreLimit:%g", endCapStyle, joinStyle, mitreLimit);
 
 	bufferparams = GEOSBufferParams_create();
 	if (bufferparams)
 	{
 		if (GEOSBufferParams_setEndCapStyle(bufferparams, endCapStyle) &&
-			GEOSBufferParams_setJoinStyle(bufferparams, joinStyle) &&
-			GEOSBufferParams_setMitreLimit(bufferparams, mitreLimit) &&
-			GEOSBufferParams_setQuadrantSegments(bufferparams, quadsegs) &&
-			GEOSBufferParams_setSingleSided(bufferparams, singleside))
+		    GEOSBufferParams_setJoinStyle(bufferparams, joinStyle) &&
+		    GEOSBufferParams_setMitreLimit(bufferparams, mitreLimit) &&
+		    GEOSBufferParams_setQuadrantSegments(bufferparams, quadsegs) &&
+		    GEOSBufferParams_setSingleSided(bufferparams, singleside))
 		{
 			g3 = GEOSBufferWithParams(g1, bufferparams, size);
 		}
@@ -1180,7 +1190,8 @@ Datum buffer(PG_FUNCTION_ARGS)
 
 	GEOSGeom_destroy(g1);
 
-	if (!g3) HANDLE_GEOS_ERROR("GEOSBuffer");
+	if (!g3)
+		HANDLE_GEOS_ERROR("GEOSBuffer");
 
 	POSTGIS_DEBUGF(3, "result: %s", GEOSGeomToWKT(g3));
 
@@ -1191,7 +1202,7 @@ Datum buffer(PG_FUNCTION_ARGS)
 
 	if (!result)
 	{
-		elog(ERROR,"GEOS buffer() threw an error (result postgis geometry formation)!");
+		elog(ERROR, "GEOS buffer() threw an error (result postgis geometry formation)!");
 		PG_RETURN_NULL(); /* never get here */
 	}
 
@@ -1200,15 +1211,16 @@ Datum buffer(PG_FUNCTION_ARGS)
 }
 
 /*
-* Generate a field of random points within the area of a
-* polygon or multipolygon. Throws an error for other geometry
-* types.
-*/
+ * Generate a field of random points within the area of a
+ * polygon or multipolygon. Throws an error for other geometry
+ * types.
+ */
 Datum ST_GeneratePoints(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_GeneratePoints);
-Datum ST_GeneratePoints(PG_FUNCTION_ARGS)
+Datum
+ST_GeneratePoints(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED	*gser_input;
+	GSERIALIZED *gser_input;
 	GSERIALIZED *gser_result;
 	LWGEOM *lwgeom_input;
 	LWGEOM *lwgeom_result;
@@ -1221,7 +1233,7 @@ Datum ST_GeneratePoints(PG_FUNCTION_ARGS)
 	if (npoints < 0)
 		PG_RETURN_NULL();
 
-	if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 	{
 		seed = PG_GETARG_INT32(2);
 		if (seed < 1)
@@ -1233,7 +1245,7 @@ Datum ST_GeneratePoints(PG_FUNCTION_ARGS)
 
 	/* Types get checked in the code, we'll keep things small out there */
 	lwgeom_input = lwgeom_from_gserialized(gser_input);
-	lwgeom_result = (LWGEOM*)lwgeom_to_points(lwgeom_input, npoints, seed);
+	lwgeom_result = (LWGEOM *)lwgeom_to_points(lwgeom_input, npoints, seed);
 	lwgeom_free(lwgeom_input);
 	PG_FREE_IF_COPY(gser_input, 0);
 
@@ -1247,15 +1259,15 @@ Datum ST_GeneratePoints(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(gser_result);
 }
 
-
 /*
-* Compute at offset curve to a line
-*/
+ * Compute at offset curve to a line
+ */
 Datum ST_OffsetCurve(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_OffsetCurve);
-Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
+Datum
+ST_OffsetCurve(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED	*gser_input;
+	GSERIALIZED *gser_input;
 	GSERIALIZED *gser_result;
 	LWGEOM *lwgeom_input;
 	LWGEOM *lwgeom_result;
@@ -1273,7 +1285,7 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 	static const double DEFAULT_MITRE_LIMIT = 5.0;
 	static const int DEFAULT_JOIN_STYLE = JOIN_ROUND;
 	double mitreLimit = DEFAULT_MITRE_LIMIT;
-	int joinStyle  = DEFAULT_JOIN_STYLE;
+	int joinStyle = DEFAULT_JOIN_STYLE;
 	char *param = NULL;
 	char *paramstr = NULL;
 
@@ -1284,30 +1296,32 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 	size = PG_GETARG_FLOAT8(1);
 
 	/* For distance == 0, just return the input. */
-	if (size == 0) PG_RETURN_POINTER(gser_input);
+	if (size == 0)
+		PG_RETURN_POINTER(gser_input);
 
 	/* Read the lwgeom, check for errors */
 	lwgeom_input = lwgeom_from_gserialized(gser_input);
-	if ( ! lwgeom_input )
+	if (!lwgeom_input)
 		lwpgerror("ST_OffsetCurve: lwgeom_from_gserialized returned NULL");
 
 	/* For empty inputs, just echo them back */
-	if ( lwgeom_is_empty(lwgeom_input) )
+	if (lwgeom_is_empty(lwgeom_input))
 		PG_RETURN_POINTER(gser_input);
 
 	/* Process the optional arguments */
-	if ( nargs > 2 )
+	if (nargs > 2)
 	{
 		text *wkttext = PG_GETARG_TEXT_P(2);
 		paramstr = text_to_cstring(wkttext);
 
 		POSTGIS_DEBUGF(3, "paramstr: %s", paramstr);
 
-		for ( param=paramstr; ; param=NULL )
+		for (param = paramstr;; param = NULL)
 		{
 			char *key, *val;
 			param = strtok(param, " ");
-			if (!param) break;
+			if (!param)
+				break;
 			POSTGIS_DEBUGF(3, "Param: %s", param);
 
 			key = param;
@@ -1322,17 +1336,17 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 
 			POSTGIS_DEBUGF(3, "Param: %s : %s", key, val);
 
-			if ( !strcmp(key, "join") )
+			if (!strcmp(key, "join"))
 			{
-				if ( !strcmp(val, "round") )
+				if (!strcmp(val, "round"))
 				{
 					joinStyle = JOIN_ROUND;
 				}
-				else if ( !(strcmp(val, "mitre") && strcmp(val, "miter")) )
+				else if (!(strcmp(val, "mitre") && strcmp(val, "miter")))
 				{
 					joinStyle = JOIN_MITRE;
 				}
-				else if ( ! strcmp(val, "bevel") )
+				else if (!strcmp(val, "bevel"))
 				{
 					joinStyle = JOIN_BEVEL;
 				}
@@ -1344,13 +1358,12 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 					break;
 				}
 			}
-			else if ( !strcmp(key, "mitre_limit") ||
-			          !strcmp(key, "miter_limit")    )
+			else if (!strcmp(key, "mitre_limit") || !strcmp(key, "miter_limit"))
 			{
 				/* mitreLimit is a float */
 				mitreLimit = atof(val);
 			}
-			else if ( !strcmp(key, "quad_segs") )
+			else if (!strcmp(key, "quad_segs"))
 			{
 				/* quadrant segments is an int */
 				quadsegs = atoi(val);
@@ -1379,7 +1392,8 @@ Datum ST_OffsetCurve(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(ST_Intersection);
-Datum ST_Intersection(PG_FUNCTION_ARGS)
+Datum
+ST_Intersection(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -1389,7 +1403,7 @@ Datum ST_Intersection(PG_FUNCTION_ARGS)
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
-	if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 		prec = PG_GETARG_FLOAT8(2);
 
 	lwgeom1 = lwgeom_from_gserialized(geom1);
@@ -1409,7 +1423,8 @@ Datum ST_Intersection(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(ST_Difference);
-Datum ST_Difference(PG_FUNCTION_ARGS)
+Datum
+ST_Difference(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	GSERIALIZED *geom2;
@@ -1419,7 +1434,7 @@ Datum ST_Difference(PG_FUNCTION_ARGS)
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 	geom2 = PG_GETARG_GSERIALIZED_P(1);
-	if (PG_NARGS() > 2 && ! PG_ARGISNULL(2))
+	if (PG_NARGS() > 2 && !PG_ARGISNULL(2))
 		prec = PG_GETARG_FLOAT8(2);
 
 	lwgeom1 = lwgeom_from_gserialized(geom1);
@@ -1443,7 +1458,8 @@ Datum ST_Difference(PG_FUNCTION_ARGS)
    0))');
 */
 PG_FUNCTION_INFO_V1(pointonsurface);
-Datum pointonsurface(PG_FUNCTION_ARGS)
+Datum
+pointonsurface(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom, *result;
 	LWGEOM *lwgeom, *lwresult;
@@ -1455,7 +1471,8 @@ Datum pointonsurface(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(geom, 0);
 
-	if (!lwresult) PG_RETURN_NULL();
+	if (!lwresult)
+		PG_RETURN_NULL();
 
 	result = geometry_serialize(lwresult);
 	lwgeom_free(lwresult);
@@ -1463,7 +1480,8 @@ Datum pointonsurface(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(centroid);
-Datum centroid(PG_FUNCTION_ARGS)
+Datum
+centroid(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom, *result;
 	LWGEOM *lwgeom, *lwresult;
@@ -1476,7 +1494,8 @@ Datum centroid(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(geom, 0);
 
-	if (!lwresult) PG_RETURN_NULL();
+	if (!lwresult)
+		PG_RETURN_NULL();
 
 	result = geometry_serialize(lwresult);
 	lwgeom_free(lwresult);
@@ -1485,7 +1504,8 @@ Datum centroid(PG_FUNCTION_ARGS)
 
 Datum ST_ReducePrecision(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_ReducePrecision);
-Datum ST_ReducePrecision(PG_FUNCTION_ARGS)
+Datum
+ST_ReducePrecision(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom, *result;
 	LWGEOM *lwgeom, *lwresult;
@@ -1497,7 +1517,8 @@ Datum ST_ReducePrecision(PG_FUNCTION_ARGS)
 	lwgeom_free(lwgeom);
 	PG_FREE_IF_COPY(geom, 0);
 
-	if (!lwresult) PG_RETURN_NULL();
+	if (!lwresult)
+		PG_RETURN_NULL();
 
 	result = geometry_serialize(lwresult);
 	lwgeom_free(lwresult);
@@ -1506,12 +1527,13 @@ Datum ST_ReducePrecision(PG_FUNCTION_ARGS)
 
 Datum ST_ClipByBox2d(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_ClipByBox2d);
-Datum ST_ClipByBox2d(PG_FUNCTION_ARGS)
+Datum
+ST_ClipByBox2d(PG_FUNCTION_ARGS)
 {
 	static const uint32_t geom_idx = 0;
 	static const uint32_t box2d_idx = 1;
 	GSERIALIZED *result;
-	LWGEOM *lwgeom1, *lwresult ;
+	LWGEOM *lwgeom1, *lwresult;
 	GBOX bbox1 = {0};
 	GBOX *bbox2;
 	uint8_t type;
@@ -1529,8 +1551,8 @@ Datum ST_ClipByBox2d(PG_FUNCTION_ARGS)
 	bbox2->flags = 0;
 
 	/* If bbox1 is strictly contained by bbox2, return input geometry */
-	if (bbox2->xmin < bbox1.xmin && bbox2->xmax > bbox1.xmax &&
-	    bbox2->ymin < bbox1.ymin && bbox2->ymax > bbox1.ymax)
+	if (bbox2->xmin < bbox1.xmin && bbox2->xmax > bbox1.xmax && bbox2->ymin < bbox1.ymin &&
+	    bbox2->ymax > bbox1.ymax)
 	{
 		PG_RETURN_DATUM(PG_GETARG_DATUM(geom_idx));
 	}
@@ -1540,29 +1562,28 @@ Datum ST_ClipByBox2d(PG_FUNCTION_ARGS)
 	{
 		/* Get type and srid from datum */
 		lwresult = lwgeom_construct_empty(type, srid, 0, 0);
-		result = geometry_serialize(lwresult) ;
-		lwgeom_free(lwresult) ;
+		result = geometry_serialize(lwresult);
+		lwgeom_free(lwresult);
 		PG_RETURN_POINTER(result);
 	}
 
 	lwgeom1 = lwgeom_from_gserialized(PG_GETARG_GSERIALIZED_P(geom_idx));
-	lwresult = lwgeom_clip_by_rect(lwgeom1, bbox2->xmin, bbox2->ymin,
-	                               bbox2->xmax, bbox2->ymax);
+	lwresult = lwgeom_clip_by_rect(lwgeom1, bbox2->xmin, bbox2->ymin, bbox2->xmax, bbox2->ymax);
 
 	lwgeom_free(lwgeom1);
 
 	if (!lwresult)
 		PG_RETURN_NULL();
 
-	result = geometry_serialize(lwresult) ;
+	result = geometry_serialize(lwresult);
 	PG_RETURN_POINTER(result);
 }
-
 
 /*---------------------------------------------*/
 
 PG_FUNCTION_INFO_V1(isvalid);
-Datum isvalid(PG_FUNCTION_ARGS)
+Datum
+isvalid(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	LWGEOM *lwgeom;
@@ -1572,20 +1593,20 @@ Datum isvalid(PG_FUNCTION_ARGS)
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 
 	/* Empty.IsValid() == TRUE */
-	if ( gserialized_is_empty(geom1) )
+	if (gserialized_is_empty(geom1))
 		PG_RETURN_BOOL(true);
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
 	lwgeom = lwgeom_from_gserialized(geom1);
-	if ( ! lwgeom )
+	if (!lwgeom)
 	{
 		lwpgerror("unable to deserialize input");
 	}
 	g1 = LWGEOM2GEOS(lwgeom, 0);
 	lwgeom_free(lwgeom);
 
-	if ( ! g1 )
+	if (!g1)
 	{
 		PG_RETURN_BOOL(false);
 	}
@@ -1595,7 +1616,7 @@ Datum isvalid(PG_FUNCTION_ARGS)
 
 	if (result == 2)
 	{
-		elog(ERROR,"GEOS isvalid() threw an error!");
+		elog(ERROR, "GEOS isvalid() threw an error!");
 		PG_RETURN_NULL(); /*never get here */
 	}
 
@@ -1604,7 +1625,8 @@ Datum isvalid(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(isvalidreason);
-Datum isvalidreason(PG_FUNCTION_ARGS)
+Datum
+isvalidreason(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom = NULL;
 	char *reason_str = NULL;
@@ -1616,11 +1638,12 @@ Datum isvalidreason(PG_FUNCTION_ARGS)
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
 	g1 = POSTGIS2GEOS(geom);
-	if ( g1 )
+	if (g1)
 	{
 		reason_str = GEOSisValidReason(g1);
 		GEOSGeom_destroy((GEOSGeometry *)g1);
-		if (!reason_str) HANDLE_GEOS_ERROR("GEOSisValidReason");
+		if (!reason_str)
+			HANDLE_GEOS_ERROR("GEOSisValidReason");
 		result = cstring_to_text(reason_str);
 		GEOSFree(reason_str);
 	}
@@ -1634,7 +1657,8 @@ Datum isvalidreason(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(isvaliddetail);
-Datum isvaliddetail(PG_FUNCTION_ARGS)
+Datum
+isvaliddetail(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom = NULL;
 	const GEOSGeometry *g1 = NULL;
@@ -1670,16 +1694,16 @@ Datum isvaliddetail(PG_FUNCTION_ARGS)
 
 	g1 = POSTGIS2GEOS(geom);
 
-	if ( g1 )
+	if (g1)
 	{
 		valid = GEOSisValidDetail(g1, flags, &geos_reason, &geos_location);
 		GEOSGeom_destroy((GEOSGeometry *)g1);
-		if ( geos_reason )
+		if (geos_reason)
 		{
 			reason = pstrdup(geos_reason);
 			GEOSFree(geos_reason);
 		}
-		if ( geos_location )
+		if (geos_location)
 		{
 			location = GEOS2LWGEOM(geos_location, GEOSHasZ(geos_location));
 			GEOSGeom_destroy(geos_location);
@@ -1699,25 +1723,25 @@ Datum isvaliddetail(PG_FUNCTION_ARGS)
 	}
 
 	/* the boolean validity */
-	values[0] =  valid ? "t" : "f";
+	values[0] = valid ? "t" : "f";
 
 	/* the reason */
-	values[1] =  reason;
+	values[1] = reason;
 
 	/* the location */
 	values[2] = location ? lwgeom_to_hexwkb_buffer(location, WKB_EXTENDED) : 0;
 
 	tuple = BuildTupleFromCStrings(attinmeta, values);
-	result = (HeapTupleHeader) palloc(tuple->t_len);
+	result = (HeapTupleHeader)palloc(tuple->t_len);
 	memcpy(result, tuple->t_data, tuple->t_len);
 	heap_freetuple(tuple);
 
 	PG_RETURN_HEAPTUPLEHEADER(result);
 }
 
-
 PG_FUNCTION_INFO_V1(issimple);
-Datum issimple(PG_FUNCTION_ARGS)
+Datum
+issimple(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom;
 	LWGEOM *lwgeom_in;
@@ -1727,15 +1751,16 @@ Datum issimple(PG_FUNCTION_ARGS)
 
 	geom = PG_GETARG_GSERIALIZED_P(0);
 
-	if ( gserialized_is_empty(geom) )
+	if (gserialized_is_empty(geom))
 		PG_RETURN_BOOL(true);
 
 	lwgeom_in = lwgeom_from_gserialized(geom);
 	result = lwgeom_is_simple(lwgeom_in);
-	lwgeom_free(lwgeom_in) ;
+	lwgeom_free(lwgeom_in);
 	PG_FREE_IF_COPY(geom, 0);
 
-	if (result == -1) {
+	if (result == -1)
+	{
 		PG_RETURN_NULL(); /*never get here */
 	}
 
@@ -1743,7 +1768,8 @@ Datum issimple(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(isring);
-Datum isring(PG_FUNCTION_ARGS)
+Datum
+isring(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom;
 	GEOSGeometry *g1;
@@ -1752,7 +1778,7 @@ Datum isring(PG_FUNCTION_ARGS)
 	geom = PG_GETARG_GSERIALIZED_P(0);
 
 	/* Empty things can't close */
-	if ( gserialized_is_empty(geom) )
+	if (gserialized_is_empty(geom))
 		PG_RETURN_BOOL(false);
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -1761,7 +1787,7 @@ Datum isring(PG_FUNCTION_ARGS)
 	if (!g1)
 		HANDLE_GEOS_ERROR("First argument geometry could not be converted to GEOS");
 
-	if ( GEOSGeomTypeId(g1) != GEOS_LINESTRING )
+	if (GEOSGeomTypeId(g1) != GEOS_LINESTRING)
 	{
 		GEOSGeom_destroy(g1);
 		elog(ERROR, "ST_IsRing() should only be called on a linear feature");
@@ -1770,7 +1796,8 @@ Datum isring(PG_FUNCTION_ARGS)
 	result = GEOSisRing(g1);
 	GEOSGeom_destroy(g1);
 
-	if (result == 2) HANDLE_GEOS_ERROR("GEOSisRing");
+	if (result == 2)
+		HANDLE_GEOS_ERROR("GEOSisRing");
 
 	PG_FREE_IF_COPY(geom, 0);
 	PG_RETURN_BOOL(result);
@@ -1783,7 +1810,7 @@ GEOS2POSTGIS(GEOSGeom geom, uint8_t want3d)
 	GSERIALIZED *result;
 
 	lwgeom = GEOS2LWGEOM(geom, want3d);
-	if ( ! lwgeom )
+	if (!lwgeom)
 	{
 		lwpgerror("%s: GEOS2LWGEOM returned NULL", __func__);
 		return NULL;
@@ -1791,7 +1818,8 @@ GEOS2POSTGIS(GEOSGeom geom, uint8_t want3d)
 
 	POSTGIS_DEBUGF(4, "%s: GEOS2LWGEOM returned a %s", __func__, lwgeom_summary(lwgeom, 0));
 
-	if (lwgeom_needs_bbox(lwgeom)) lwgeom_add_bbox(lwgeom);
+	if (lwgeom_needs_bbox(lwgeom))
+		lwgeom_add_bbox(lwgeom);
 
 	result = geometry_serialize(lwgeom);
 	lwgeom_free(lwgeom);
@@ -1806,7 +1834,7 @@ POSTGIS2GEOS(const GSERIALIZED *pglwgeom)
 {
 	GEOSGeometry *ret;
 	LWGEOM *lwgeom = lwgeom_from_gserialized(pglwgeom);
-	if ( ! lwgeom )
+	if (!lwgeom)
 	{
 		lwpgerror("POSTGIS2GEOS: unable to deserialize input");
 		return NULL;
@@ -1818,14 +1846,14 @@ POSTGIS2GEOS(const GSERIALIZED *pglwgeom)
 }
 
 static uint32_t
-array_nelems_not_null(ArrayType* array)
+array_nelems_not_null(ArrayType *array)
 {
 	ArrayIterator iterator;
 	Datum value;
 	bool isnull;
 	uint32_t nelems_not_null = 0;
 	iterator = array_create_iterator(array, 0, NULL);
-	while(array_iterate(iterator, &value, &isnull))
+	while (array_iterate(iterator, &value, &isnull))
 	{
 		if (!isnull)
 			nelems_not_null++;
@@ -1837,76 +1865,79 @@ array_nelems_not_null(ArrayType* array)
 }
 
 /* ARRAY2LWGEOM: Converts the non-null elements of a Postgres array into a LWGEOM* array */
-LWGEOM** ARRAY2LWGEOM(ArrayType* array, uint32_t nelems,  int* is3d, int* srid)
+LWGEOM **
+ARRAY2LWGEOM(ArrayType *array, uint32_t nelems, int *is3d, int *srid)
 {
-    ArrayIterator iterator;
-    Datum value;
-    bool isnull;
-    bool gotsrid = false;
-    uint32_t i = 0;
+	ArrayIterator iterator;
+	Datum value;
+	bool isnull;
+	bool gotsrid = false;
+	uint32_t i = 0;
 
-	LWGEOM** lw_geoms = palloc(nelems * sizeof(LWGEOM*));
+	LWGEOM **lw_geoms = palloc(nelems * sizeof(LWGEOM *));
 
-    iterator = array_create_iterator(array, 0, NULL);
+	iterator = array_create_iterator(array, 0, NULL);
 
-    while (array_iterate(iterator, &value, &isnull))
-    {
-	    GSERIALIZED *geom = (GSERIALIZED *)DatumGetPointer(value);
+	while (array_iterate(iterator, &value, &isnull))
+	{
+		GSERIALIZED *geom = (GSERIALIZED *)DatumGetPointer(value);
 
-	    if (isnull)
-		    continue;
+		if (isnull)
+			continue;
 
-	    *is3d = *is3d || gserialized_has_z(geom);
+		*is3d = *is3d || gserialized_has_z(geom);
 
-	    lw_geoms[i] = lwgeom_from_gserialized(geom);
-	    if (!lw_geoms[i]) /* error in creation */
-	    {
-		    lwpgerror("Geometry deserializing geometry");
-		    return NULL;
-	    }
-	    if (!gotsrid)
-	    {
-		    gotsrid = true;
-		    *srid = gserialized_get_srid(geom);
-	    }
-	    else
-		    gserialized_error_if_srid_mismatch_reference(geom, *srid, __func__);
+		lw_geoms[i] = lwgeom_from_gserialized(geom);
+		if (!lw_geoms[i]) /* error in creation */
+		{
+			lwpgerror("Geometry deserializing geometry");
+			return NULL;
+		}
+		if (!gotsrid)
+		{
+			gotsrid = true;
+			*srid = gserialized_get_srid(geom);
+		}
+		else
+			gserialized_error_if_srid_mismatch_reference(geom, *srid, __func__);
 
-	    i++;
-    }
+		i++;
+	}
 
 	return lw_geoms;
 }
 
 /* ARRAY2GEOS: Converts the non-null elements of a Postgres array into a GEOSGeometry* array */
-GEOSGeometry** ARRAY2GEOS(ArrayType* array, uint32_t nelems, int* is3d, int* srid)
+GEOSGeometry **
+ARRAY2GEOS(ArrayType *array, uint32_t nelems, int *is3d, int *srid)
 {
-    ArrayIterator iterator;
-    Datum value;
-    bool isnull;
-    bool gotsrid = false;
-    uint32_t i = 0;
+	ArrayIterator iterator;
+	Datum value;
+	bool isnull;
+	bool gotsrid = false;
+	uint32_t i = 0;
 
-	GEOSGeometry** geos_geoms = palloc(nelems * sizeof(GEOSGeometry*));
+	GEOSGeometry **geos_geoms = palloc(nelems * sizeof(GEOSGeometry *));
 
-    iterator = array_create_iterator(array, 0, NULL);
+	iterator = array_create_iterator(array, 0, NULL);
 
-    while(array_iterate(iterator, &value, &isnull))
+	while (array_iterate(iterator, &value, &isnull))
 	{
-        GSERIALIZED *geom = (GSERIALIZED*) DatumGetPointer(value);
+		GSERIALIZED *geom = (GSERIALIZED *)DatumGetPointer(value);
 
-        if (isnull)
-            continue;
+		if (isnull)
+			continue;
 
 		*is3d = *is3d || gserialized_has_z(geom);
 
 		geos_geoms[i] = POSTGIS2GEOS(geom);
 		if (!geos_geoms[i])
 		{
-            uint32_t j;
-            lwpgerror("Geometry could not be converted to GEOS");
+			uint32_t j;
+			lwpgerror("Geometry could not be converted to GEOS");
 
-			for (j = 0; j < i; j++) {
+			for (j = 0; j < i; j++)
+			{
 				GEOSGeom_destroy(geos_geoms[j]);
 			}
 			return NULL;
@@ -1915,27 +1946,29 @@ GEOSGeometry** ARRAY2GEOS(ArrayType* array, uint32_t nelems, int* is3d, int* sri
 		if (!gotsrid)
 		{
 			*srid = gserialized_get_srid(geom);
-            gotsrid = true;
+			gotsrid = true;
 		}
 		else if (*srid != gserialized_get_srid(geom))
 		{
-            uint32_t j;
-            for (j = 0; j <= i; j++) {
+			uint32_t j;
+			for (j = 0; j <= i; j++)
+			{
 				GEOSGeom_destroy(geos_geoms[j]);
 			}
 			gserialized_error_if_srid_mismatch_reference(geom, *srid, __func__);
 			return NULL;
 		}
 
-        i++;
+		i++;
 	}
 
-    array_free_iterator(iterator);
+	array_free_iterator(iterator);
 	return geos_geoms;
 }
 
 PG_FUNCTION_INFO_V1(GEOSnoop);
-Datum GEOSnoop(PG_FUNCTION_ARGS)
+Datum
+GEOSnoop(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom;
 	GEOSGeometry *geosgeom;
@@ -1945,7 +1978,8 @@ Datum GEOSnoop(PG_FUNCTION_ARGS)
 
 	geom = PG_GETARG_GSERIALIZED_P(0);
 	geosgeom = POSTGIS2GEOS(geom);
-	if ( ! geosgeom ) PG_RETURN_NULL();
+	if (!geosgeom)
+		PG_RETURN_NULL();
 
 	lwgeom_result = GEOS2POSTGIS(geosgeom, gserialized_has_z(geom));
 	GEOSGeom_destroy(geosgeom);
@@ -1956,7 +1990,8 @@ Datum GEOSnoop(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(polygonize_garray);
-Datum polygonize_garray(PG_FUNCTION_ARGS)
+Datum
+polygonize_garray(PG_FUNCTION_ARGS)
 {
 	ArrayType *array;
 	int is3d = 0;
@@ -1980,7 +2015,7 @@ Datum polygonize_garray(PG_FUNCTION_ARGS)
 	/* Ok, we really need geos now ;) */
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
-	vgeoms = (const GEOSGeometry**) ARRAY2GEOS(array, nelems, &is3d, &srid);
+	vgeoms = (const GEOSGeometry **)ARRAY2GEOS(array, nelems, &is3d, &srid);
 
 	POSTGIS_DEBUG(3, "polygonize_garray: invoking GEOSpolygonize");
 
@@ -1988,10 +2023,12 @@ Datum polygonize_garray(PG_FUNCTION_ARGS)
 
 	POSTGIS_DEBUG(3, "polygonize_garray: GEOSpolygonize returned");
 
-	for (i=0; i<nelems; ++i) GEOSGeom_destroy((GEOSGeometry *)vgeoms[i]);
+	for (i = 0; i < nelems; ++i)
+		GEOSGeom_destroy((GEOSGeometry *)vgeoms[i]);
 	pfree(vgeoms);
 
-	if ( ! geos_result ) PG_RETURN_NULL();
+	if (!geos_result)
+		PG_RETURN_NULL();
 
 	GEOSSetSRID(geos_result, srid);
 	result = GEOS2POSTGIS(geos_result, is3d);
@@ -2005,11 +2042,11 @@ Datum polygonize_garray(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
-
 PG_FUNCTION_INFO_V1(clusterintersecting_garray);
-Datum clusterintersecting_garray(PG_FUNCTION_ARGS)
+Datum
+clusterintersecting_garray(PG_FUNCTION_ARGS)
 {
-	Datum* result_array_data;
+	Datum *result_array_data;
 	ArrayType *array, *result;
 	int is3d = 0;
 	uint32 nelems, nclusters, i;
@@ -2027,19 +2064,20 @@ Datum clusterintersecting_garray(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	array = PG_GETARG_ARRAYTYPE_P(0);
-    nelems = array_nelems_not_null(array);
+	nelems = array_nelems_not_null(array);
 
 	POSTGIS_DEBUGF(3, "clusterintersecting_garray: number of non-null elements: %d", nelems);
 
-	if ( nelems == 0 ) PG_RETURN_NULL();
+	if (nelems == 0)
+		PG_RETURN_NULL();
 
-    /* TODO short-circuit for one element? */
+	/* TODO short-circuit for one element? */
 
 	/* Ok, we really need geos now ;) */
 	initGEOS(lwpgnotice, lwgeom_geos_error);
 
 	geos_inputs = ARRAY2GEOS(array, nelems, &is3d, &srid);
-	if(!geos_inputs)
+	if (!geos_inputs)
 	{
 		PG_RETURN_NULL();
 	}
@@ -2051,10 +2089,11 @@ Datum clusterintersecting_garray(PG_FUNCTION_ARGS)
 	}
 	pfree(geos_inputs); /* don't need to destroy items because GeometryCollections have taken ownership */
 
-	if (!geos_results) PG_RETURN_NULL();
+	if (!geos_results)
+		PG_RETURN_NULL();
 
 	result_array_data = palloc(nclusters * sizeof(Datum));
-	for (i=0; i<nclusters; ++i)
+	for (i = 0; i < nclusters; ++i)
 	{
 		result_array_data[i] = PointerGetDatum(GEOS2POSTGIS(geos_results[i], is3d));
 		GEOSGeom_destroy(geos_results[i]);
@@ -2074,14 +2113,15 @@ Datum clusterintersecting_garray(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(cluster_within_distance_garray);
-Datum cluster_within_distance_garray(PG_FUNCTION_ARGS)
+Datum
+cluster_within_distance_garray(PG_FUNCTION_ARGS)
 {
-	Datum* result_array_data;
+	Datum *result_array_data;
 	ArrayType *array, *result;
 	int is3d = 0;
 	uint32 nelems, nclusters, i;
-	LWGEOM** lw_inputs;
-	LWGEOM** lw_results;
+	LWGEOM **lw_inputs;
+	LWGEOM **lw_results;
 	double tolerance;
 	int32_t srid = SRID_UNKNOWN;
 
@@ -2107,9 +2147,10 @@ Datum cluster_within_distance_garray(PG_FUNCTION_ARGS)
 
 	POSTGIS_DEBUGF(3, "cluster_within_distance_garray: number of non-null elements: %d", nelems);
 
-	if ( nelems == 0 ) PG_RETURN_NULL();
+	if (nelems == 0)
+		PG_RETURN_NULL();
 
-    /* TODO short-circuit for one element? */
+	/* TODO short-circuit for one element? */
 
 	/* Ok, we really need geos now ;) */
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -2127,10 +2168,11 @@ Datum cluster_within_distance_garray(PG_FUNCTION_ARGS)
 	}
 	pfree(lw_inputs); /* don't need to destroy items because GeometryCollections have taken ownership */
 
-	if (!lw_results) PG_RETURN_NULL();
+	if (!lw_results)
+		PG_RETURN_NULL();
 
 	result_array_data = palloc(nclusters * sizeof(Datum));
-	for (i=0; i<nclusters; ++i)
+	for (i = 0; i < nclusters; ++i)
 	{
 		result_array_data[i] = PointerGetDatum(geometry_serialize(lw_results[i]));
 		lwgeom_free(lw_results[i]);
@@ -2138,7 +2180,7 @@ Datum cluster_within_distance_garray(PG_FUNCTION_ARGS)
 	lwfree(lw_results);
 
 	get_typlenbyvalalign(array->elemtype, &elmlen, &elmbyval, &elmalign);
-	result =  construct_array(result_array_data, nclusters, array->elemtype, elmlen, elmbyval, elmalign);
+	result = construct_array(result_array_data, nclusters, array->elemtype, elmlen, elmbyval, elmalign);
 
 	if (!result)
 	{
@@ -2150,25 +2192,26 @@ Datum cluster_within_distance_garray(PG_FUNCTION_ARGS)
 }
 
 PG_FUNCTION_INFO_V1(linemerge);
-Datum linemerge(PG_FUNCTION_ARGS)
+Datum
+linemerge(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1;
 	bool directed = false;
 	GSERIALIZED *result;
-	LWGEOM *lwgeom1, *lwresult ;
+	LWGEOM *lwgeom1, *lwresult;
 
 	geom1 = PG_GETARG_GSERIALIZED_P(0);
 
-	if ( PG_NARGS() > 1 )
+	if (PG_NARGS() > 1)
 		directed = PG_GETARG_BOOL(1);
 
-	lwgeom1 = lwgeom_from_gserialized(geom1) ;
+	lwgeom1 = lwgeom_from_gserialized(geom1);
 
 	lwresult = lwgeom_linemerge_directed(lwgeom1, directed ? LW_TRUE : LW_FALSE);
-	result = geometry_serialize(lwresult) ;
+	result = geometry_serialize(lwresult);
 
-	lwgeom_free(lwgeom1) ;
-	lwgeom_free(lwresult) ;
+	lwgeom_free(lwgeom1);
+	lwgeom_free(lwresult);
 
 	PG_FREE_IF_COPY(geom1, 0);
 
@@ -2183,7 +2226,8 @@ Datum linemerge(PG_FUNCTION_ARGS)
  * a valid polygon Geometry.
  */
 PG_FUNCTION_INFO_V1(ST_BuildArea);
-Datum ST_BuildArea(PG_FUNCTION_ARGS)
+Datum
+ST_BuildArea(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *result;
 	GSERIALIZED *geom;
@@ -2194,16 +2238,16 @@ Datum ST_BuildArea(PG_FUNCTION_ARGS)
 	lwgeom_in = lwgeom_from_gserialized(geom);
 
 	lwgeom_out = lwgeom_buildarea(lwgeom_in);
-	lwgeom_free(lwgeom_in) ;
+	lwgeom_free(lwgeom_in);
 
-	if ( ! lwgeom_out )
+	if (!lwgeom_out)
 	{
 		PG_FREE_IF_COPY(geom, 0);
 		PG_RETURN_NULL();
 	}
 
-	result = geometry_serialize(lwgeom_out) ;
-	lwgeom_free(lwgeom_out) ;
+	result = geometry_serialize(lwgeom_out);
+	lwgeom_free(lwgeom_out);
 
 	PG_FREE_IF_COPY(geom, 0);
 	PG_RETURN_POINTER(result);
@@ -2214,12 +2258,13 @@ Datum ST_BuildArea(PG_FUNCTION_ARGS)
  * Delaunay triangles around them.
  */
 PG_FUNCTION_INFO_V1(ST_DelaunayTriangles);
-Datum ST_DelaunayTriangles(PG_FUNCTION_ARGS)
+Datum
+ST_DelaunayTriangles(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *result;
 	GSERIALIZED *geom;
 	LWGEOM *lwgeom_in, *lwgeom_out;
-	double	tolerance = 0.0;
+	double tolerance = 0.0;
 	int flags = 0;
 
 	geom = PG_GETARG_GSERIALIZED_P(0);
@@ -2230,16 +2275,16 @@ Datum ST_DelaunayTriangles(PG_FUNCTION_ARGS)
 
 	lwgeom_in = lwgeom_from_gserialized(geom);
 	lwgeom_out = lwgeom_delaunay_triangulation(lwgeom_in, tolerance, flags);
-	lwgeom_free(lwgeom_in) ;
+	lwgeom_free(lwgeom_in);
 
-	if ( ! lwgeom_out )
+	if (!lwgeom_out)
 	{
 		PG_FREE_IF_COPY(geom, 0);
 		PG_RETURN_NULL();
 	}
 
-	result = geometry_serialize(lwgeom_out) ;
-	lwgeom_free(lwgeom_out) ;
+	result = geometry_serialize(lwgeom_out);
+	lwgeom_free(lwgeom_out);
 
 	PG_FREE_IF_COPY(geom, 0);
 	PG_RETURN_POINTER(result);
@@ -2251,14 +2296,16 @@ Datum ST_DelaunayTriangles(PG_FUNCTION_ARGS)
  * polygon.
  */
 PG_FUNCTION_INFO_V1(ST_TriangulatePolygon);
-Datum ST_TriangulatePolygon(PG_FUNCTION_ARGS)
+Datum
+ST_TriangulatePolygon(PG_FUNCTION_ARGS)
 {
 #if POSTGIS_GEOS_VERSION < 31100
 
-	lwpgerror("The GEOS version this PostGIS binary "
-	          "was compiled against (%d) doesn't support "
-	          "'GEOSConstrainedDelaunayTriangulation' function (3.11.0+ required)",
-	          POSTGIS_GEOS_VERSION);
+	lwpgerror(
+	    "The GEOS version this PostGIS binary "
+	    "was compiled against (%d) doesn't support "
+	    "'GEOSConstrainedDelaunayTriangulation' function (3.11.0+ required)",
+	    POSTGIS_GEOS_VERSION);
 	PG_RETURN_NULL();
 
 #else /* POSTGIS_GEOS_VERSION >= 31100 */
@@ -2289,7 +2336,8 @@ Datum ST_TriangulatePolygon(PG_FUNCTION_ARGS)
  */
 Datum ST_Snap(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_Snap);
-Datum ST_Snap(PG_FUNCTION_ARGS)
+Datum
+ST_Snap(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1, *geom2, *result;
 	LWGEOM *lwgeom1, *lwgeom2, *lwresult;
@@ -2340,7 +2388,8 @@ Datum ST_Snap(PG_FUNCTION_ARGS)
  */
 Datum ST_Split(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_Split);
-Datum ST_Split(PG_FUNCTION_ARGS)
+Datum
+ST_Split(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *in, *blade_in, *out;
 	LWGEOM *lwgeom_in, *lwblade_in, *lwgeom_out;
@@ -2364,12 +2413,11 @@ Datum ST_Split(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 	}
 
-
 	lwgeom_out = lwgeom_split(lwgeom_in, lwblade_in);
 	lwgeom_free(lwgeom_in);
 	lwgeom_free(lwblade_in);
 
-	if ( ! lwgeom_out )
+	if (!lwgeom_out)
 	{
 		PG_FREE_IF_COPY(in, 0); /* possibly referenced by lwgeom_out */
 		PG_FREE_IF_COPY(blade_in, 1);
@@ -2401,7 +2449,8 @@ Datum ST_Split(PG_FUNCTION_ARGS)
  **********************************************************************/
 Datum ST_SharedPaths(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_SharedPaths);
-Datum ST_SharedPaths(PG_FUNCTION_ARGS)
+Datum
+ST_SharedPaths(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1, *geom2, *out;
 	LWGEOM *g1, *g2, *lwgeom_out;
@@ -2416,7 +2465,7 @@ Datum ST_SharedPaths(PG_FUNCTION_ARGS)
 	lwgeom_free(g1);
 	lwgeom_free(g2);
 
-	if ( ! lwgeom_out )
+	if (!lwgeom_out)
 	{
 		PG_FREE_IF_COPY(geom1, 0);
 		PG_FREE_IF_COPY(geom2, 1);
@@ -2431,7 +2480,6 @@ Datum ST_SharedPaths(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(out);
 }
 
-
 /**********************************************************************
  *
  * ST_Node
@@ -2442,7 +2490,8 @@ Datum ST_SharedPaths(PG_FUNCTION_ARGS)
  **********************************************************************/
 Datum ST_Node(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_Node);
-Datum ST_Node(PG_FUNCTION_ARGS)
+Datum
+ST_Node(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1, *out;
 	LWGEOM *g1, *lwgeom_out;
@@ -2454,7 +2503,7 @@ Datum ST_Node(PG_FUNCTION_ARGS)
 	lwgeom_out = lwgeom_node(g1);
 	lwgeom_free(g1);
 
-	if ( ! lwgeom_out )
+	if (!lwgeom_out)
 	{
 		PG_FREE_IF_COPY(geom1, 0);
 		PG_RETURN_NULL();
@@ -2477,13 +2526,14 @@ Datum ST_Node(PG_FUNCTION_ARGS)
  ******************************************/
 Datum ST_Voronoi(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_Voronoi);
-Datum ST_Voronoi(PG_FUNCTION_ARGS)
+Datum
+ST_Voronoi(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* input;
-	GSERIALIZED* clip;
-	GSERIALIZED* result;
-	LWGEOM* lwgeom_input;
-	LWGEOM* lwgeom_result;
+	GSERIALIZED *input;
+	GSERIALIZED *clip;
+	GSERIALIZED *result;
+	LWGEOM *lwgeom_input;
+	LWGEOM *lwgeom_result;
 	double tolerance;
 	GBOX clip_envelope;
 	int custom_clip_envelope;
@@ -2518,7 +2568,8 @@ Datum ST_Voronoi(PG_FUNCTION_ARGS)
 
 	/* Read our clipping envelope, if applicable. */
 	custom_clip_envelope = !PG_ARGISNULL(1);
-	if (custom_clip_envelope) {
+	if (custom_clip_envelope)
+	{
 		clip = PG_GETARG_GSERIALIZED_P(1);
 		if (!gserialized_get_gbox_p(clip, &clip_envelope))
 		{
@@ -2536,14 +2587,15 @@ Datum ST_Voronoi(PG_FUNCTION_ARGS)
 
 	lwgeom_input = lwgeom_from_gserialized(input);
 
-	if(!lwgeom_input)
+	if (!lwgeom_input)
 	{
 		lwpgerror("Could not read input geometry.");
 		PG_FREE_IF_COPY(input, 0);
 		PG_RETURN_NULL();
 	}
 
-	lwgeom_result = lwgeom_voronoi_diagram(lwgeom_input, custom_clip_envelope ? &clip_envelope : NULL, tolerance, !return_polygons);
+	lwgeom_result = lwgeom_voronoi_diagram(
+	    lwgeom_input, custom_clip_envelope ? &clip_envelope : NULL, tolerance, !return_polygons);
 	lwgeom_free(lwgeom_input);
 
 	if (!lwgeom_result)
@@ -2569,10 +2621,11 @@ Datum ST_Voronoi(PG_FUNCTION_ARGS)
  ******************************************/
 Datum ST_MinimumClearance(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_MinimumClearance);
-Datum ST_MinimumClearance(PG_FUNCTION_ARGS)
+Datum
+ST_MinimumClearance(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* input;
-	GEOSGeometry* input_geos;
+	GSERIALIZED *input;
+	GEOSGeometry *input_geos;
 	int error;
 	double result;
 
@@ -2585,7 +2638,8 @@ Datum ST_MinimumClearance(PG_FUNCTION_ARGS)
 
 	error = GEOSMinimumClearance(input_geos, &result);
 	GEOSGeom_destroy(input_geos);
-	if (error) HANDLE_GEOS_ERROR("Error computing minimum clearance");
+	if (error)
+		HANDLE_GEOS_ERROR("Error computing minimum clearance");
 
 	PG_FREE_IF_COPY(input, 0);
 	PG_RETURN_FLOAT8(result);
@@ -2600,12 +2654,13 @@ Datum ST_MinimumClearance(PG_FUNCTION_ARGS)
  ******************************************/
 Datum ST_MinimumClearanceLine(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_MinimumClearanceLine);
-Datum ST_MinimumClearanceLine(PG_FUNCTION_ARGS)
+Datum
+ST_MinimumClearanceLine(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* input;
-	GSERIALIZED* result;
-	GEOSGeometry* input_geos;
-	GEOSGeometry* result_geos;
+	GSERIALIZED *input;
+	GSERIALIZED *result;
+	GEOSGeometry *input_geos;
+	GEOSGeometry *result_geos;
 	int32_t srid;
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -2636,12 +2691,13 @@ Datum ST_MinimumClearanceLine(PG_FUNCTION_ARGS)
  ******************************************/
 Datum ST_OrientedEnvelope(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(ST_OrientedEnvelope);
-Datum ST_OrientedEnvelope(PG_FUNCTION_ARGS)
+Datum
+ST_OrientedEnvelope(PG_FUNCTION_ARGS)
 {
-	GSERIALIZED* input;
-	GSERIALIZED* result;
-	GEOSGeometry* input_geos;
-	GEOSGeometry* result_geos;
+	GSERIALIZED *input;
+	GSERIALIZED *result;
+	GEOSGeometry *input_geos;
+	GEOSGeometry *result_geos;
 	int32_t srid;
 
 	initGEOS(lwpgnotice, lwgeom_geos_error);
@@ -2665,15 +2721,15 @@ Datum ST_OrientedEnvelope(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(result);
 }
 
-
 /**
-* Returns boolean true if the second argument
-* is fully contained in a buffer of the first
-* argument.
-*/
+ * Returns boolean true if the second argument
+ * is fully contained in a buffer of the first
+ * argument.
+ */
 Datum LWGEOM_dfullywithin(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(LWGEOM_dfullywithin);
-Datum LWGEOM_dfullywithin(PG_FUNCTION_ARGS)
+Datum
+LWGEOM_dfullywithin(PG_FUNCTION_ARGS)
 {
 	GSERIALIZED *geom1 = PG_GETARG_GSERIALIZED_P(0);
 	GSERIALIZED *geom2 = PG_GETARG_GSERIALIZED_P(1);
@@ -2716,7 +2772,8 @@ Datum LWGEOM_dfullywithin(PG_FUNCTION_ARGS)
 	GEOSGeom_destroy(buffer1);
 	GEOSGeom_destroy(geos2);
 
-	if (contained == 2) HANDLE_GEOS_ERROR("GEOSContains");
+	if (contained == 2)
+		HANDLE_GEOS_ERROR("GEOSContains");
 
 	PG_FREE_IF_COPY(geom1, 0);
 	PG_FREE_IF_COPY(geom2, 1);

--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -223,6 +223,7 @@ strsplit(const char *str, const char *delimiter, uint32_t *n)
 	char *tmp = NULL;
 	char **rtn = NULL;
 	char *token = NULL;
+	char *saveptr = NULL;
 
 	*n = 0;
 	if (!str)
@@ -257,7 +258,7 @@ strsplit(const char *str, const char *delimiter, uint32_t *n)
 		return rtn;
 	}
 
-	token = strtok(tmp, delimiter);
+	token = strtok_r(tmp, delimiter, &saveptr);
 	while (token != NULL)
 	{
 		if (*n < 1)
@@ -285,7 +286,7 @@ strsplit(const char *str, const char *delimiter, uint32_t *n)
 		strcpy(rtn[*n], token);
 		*n = *n + 1;
 
-		token = strtok(NULL, delimiter);
+		token = strtok_r(NULL, delimiter, &saveptr);
 	}
 
 	rtdealloc(tmp);

--- a/raster/loader/raster2pgsql.c
+++ b/raster/loader/raster2pgsql.c
@@ -33,11 +33,11 @@
 #define xstr(s) str(s)
 #define str(s) #s
 
-static void
-loader_rt_error_handler(const char *fmt, va_list ap) __attribute__ ((format (printf, 1, 0)));
+static void loader_rt_error_handler(const char *fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 static void
-loader_rt_error_handler(const char *fmt, va_list ap) {
+loader_rt_error_handler(const char *fmt, va_list ap)
+{
 	static const char *label = "ERROR: ";
 	char newfmt[1024] = {0};
 	snprintf(newfmt, 1024, "%s%s\n", label, fmt);
@@ -46,11 +46,11 @@ loader_rt_error_handler(const char *fmt, va_list ap) {
 	va_end(ap);
 }
 
-static void
-loader_rt_warning_handler(const char *fmt, va_list ap) __attribute__ ((format (printf, 1, 0)));
+static void loader_rt_warning_handler(const char *fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 static void
-loader_rt_warning_handler(const char *fmt, va_list ap) {
+loader_rt_warning_handler(const char *fmt, va_list ap)
+{
 	static const char *label = "WARNING: ";
 	char newfmt[1024] = {0};
 	snprintf(newfmt, 1024, "%s%s\n", label, fmt);
@@ -59,11 +59,11 @@ loader_rt_warning_handler(const char *fmt, va_list ap) {
 	va_end(ap);
 }
 
-static void
-loader_rt_info_handler(const char *fmt, va_list ap) __attribute__ ((format (printf, 1, 0)));
+static void loader_rt_info_handler(const char *fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 static void
-loader_rt_info_handler(const char *fmt, va_list ap) {
+loader_rt_info_handler(const char *fmt, va_list ap)
+{
 	static const char *label = "INFO: ";
 	char newfmt[1024] = {0};
 	snprintf(newfmt, 1024, "%s%s\n", label, fmt);
@@ -73,28 +73,32 @@ loader_rt_info_handler(const char *fmt, va_list ap) {
 }
 
 static void
-rt_init_allocators(void) {
-	rt_set_handlers(
-		default_rt_allocator,
-		default_rt_reallocator,
-		default_rt_deallocator,
-		loader_rt_error_handler,
-		loader_rt_info_handler,
-		loader_rt_warning_handler
-	);
+rt_init_allocators(void)
+{
+	rt_set_handlers(default_rt_allocator,
+			default_rt_reallocator,
+			default_rt_deallocator,
+			loader_rt_error_handler,
+			loader_rt_info_handler,
+			loader_rt_warning_handler);
 }
 
 static void
-raster_destroy(rt_raster raster) {
+raster_destroy(rt_raster raster)
+{
 	uint16_t i;
 	uint16_t nbands = rt_raster_get_num_bands(raster);
-	for (i = 0; i < nbands; i++) {
+	for (i = 0; i < nbands; i++)
+	{
 		rt_band band = rt_raster_get_band(raster, i);
-		if (band == NULL) continue;
+		if (band == NULL)
+			continue;
 
-		if (!rt_band_is_offline(band) && !rt_band_get_ownsdata_flag(band)) {
-			void* mem = rt_band_get_data(band);
-			if (mem) rtdealloc(mem);
+		if (!rt_band_is_offline(band) && !rt_band_get_ownsdata_flag(band))
+		{
+			void *mem = rt_band_get_data(band);
+			if (mem)
+				rtdealloc(mem);
 		}
 		rt_band_destroy(band);
 	}
@@ -102,27 +106,33 @@ raster_destroy(rt_raster raster) {
 }
 
 static int
-array_range(int min, int max, int step, int **range, uint32_t *len) {
+array_range(int min, int max, int step, int **range, uint32_t *len)
+{
 	int i = 0;
 	int j = 0;
 
 	step = abs(step);
-	*len = (uint32_t) ((abs(max - min) + 1 + (step / 2)) / step);
+	*len = (uint32_t)((abs(max - min) + 1 + (step / 2)) / step);
 	*range = rtalloc(sizeof(int) * *len);
 
-	if (min < max) {
+	if (min < max)
+	{
 		for (i = min, j = 0; i <= max; i += step, j++)
 			(*range)[j] = i;
 	}
-	else if (max < min) {
-		if (step > 0) step *= -1;
+	else if (max < min)
+	{
+		if (step > 0)
+			step *= -1;
 		for (i = min, j = 0; i >= max; i += step, j++)
 			(*range)[j] = i;
 	}
-	else if (min == max) {
+	else if (min == max)
+	{
 		(*range)[0] = min;
 	}
-	else {
+	else
+	{
 		*len = 0;
 		*range = NULL;
 		return 0;
@@ -142,19 +152,16 @@ array_range(int min, int max, int step, int **range, uint32_t *len) {
       oldstr : Substring we are looking for
       newstr : Substring we want to replace with
       count  : Optional pointer to int (input / output value). NULL to ignore.
-               Input:  Maximum replacements to be done. NULL or < 1 to do all.
-               Output: Number of replacements done or -1 if not enough memory.
+	       Input:  Maximum replacements to be done. NULL or < 1 to do all.
+	       Output: Number of replacements done or -1 if not enough memory.
   Returns    : Pointer to the new string or NULL if error.
   Notes      :
      - Case sensitive - Otherwise, replace functions "strstr" by "strcasestr"
      - Always allocates memory for the result.
 --------------------------------------------------------------------------- */
-static char*
-strreplace(
-	const char *str,
-	const char *oldstr, const char *newstr,
-	int *count
-) {
+static char *
+strreplace(const char *str, const char *oldstr, const char *newstr, int *count)
+{
 	const char *tmp = str;
 	char *result;
 	int found = 0;
@@ -168,19 +175,22 @@ strreplace(
 		found++, tmp += oldlen;
 
 	length = (int)strlen(str) + found * (newlen - oldlen);
-	if ((result = (char *) rtalloc(length + 1)) == NULL) {
+	if ((result = (char *)rtalloc(length + 1)) == NULL)
+	{
 		rterror(_("strreplace: Not enough memory"));
 		found = -1;
 	}
-	else {
+	else
+	{
 		tmp = str;
 		limit = found; /* Countdown */
-		reslen = 0; /* length of current result */
+		reslen = 0;    /* length of current result */
 
 		/* Replace each old string found with new string  */
-		while ((limit-- > 0) && (tmp = strstr(tmp, oldstr)) != NULL) {
-			length = (tmp - str); /* Number of chars to keep intouched */
-			strncpy(result + reslen, str, length); /* Original part keeped */
+		while ((limit-- > 0) && (tmp = strstr(tmp, oldstr)) != NULL)
+		{
+			length = (tmp - str);                        /* Number of chars to keep intouched */
+			strncpy(result + reslen, str, length);       /* Original part keeped */
 			strcpy(result + (reslen += length), newstr); /* Insert new string */
 
 			reslen += newlen;
@@ -190,12 +200,14 @@ strreplace(
 		strcpy(result + reslen, str); /* Copies last part and ending null char */
 	}
 
-	if (count != NULL) *count = found;
+	if (count != NULL)
+		*count = found;
 	return result;
 }
 
 static char *
-strtolower(char * str) {
+strtolower(char *str)
+{
 	int j;
 
 	for (j = strlen(str) - 1; j >= 0; j--)
@@ -205,8 +217,9 @@ strtolower(char * str) {
 }
 
 /* split a string based on a delimiter */
-static char**
-strsplit(const char *str, const char *delimiter, uint32_t *n) {
+static char **
+strsplit(const char *str, const char *delimiter, uint32_t *n)
+{
 	char *tmp = NULL;
 	char **rtn = NULL;
 	char *token = NULL;
@@ -217,21 +230,25 @@ strsplit(const char *str, const char *delimiter, uint32_t *n) {
 
 	/* copy str to tmp as strtok will mangle the string */
 	tmp = rtalloc(sizeof(char) * (strlen(str) + 1));
-	if (NULL == tmp) {
+	if (NULL == tmp)
+	{
 		rterror(_("strsplit: Not enough memory"));
 		return NULL;
 	}
 	strcpy(tmp, str);
 
-	if (!strlen(tmp) || !delimiter || !strlen(delimiter)) {
+	if (!strlen(tmp) || !delimiter || !strlen(delimiter))
+	{
 		*n = 1;
-		rtn = (char **) rtalloc(*n * sizeof(char *));
-		if (NULL == rtn) {
+		rtn = (char **)rtalloc(*n * sizeof(char *));
+		if (NULL == rtn)
+		{
 			rterror(_("strsplit: Not enough memory"));
 			return NULL;
 		}
-		rtn[0] = (char *) rtalloc(sizeof(char) * (strlen(tmp) + 1));
-		if (NULL == rtn[0]) {
+		rtn[0] = (char *)rtalloc(sizeof(char) * (strlen(tmp) + 1));
+		if (NULL == rtn[0])
+		{
 			rterror(_("strsplit: Not enough memory"));
 			return NULL;
 		}
@@ -241,21 +258,26 @@ strsplit(const char *str, const char *delimiter, uint32_t *n) {
 	}
 
 	token = strtok(tmp, delimiter);
-	while (token != NULL) {
-		if (*n < 1) {
-			rtn = (char **) rtalloc(sizeof(char *));
+	while (token != NULL)
+	{
+		if (*n < 1)
+		{
+			rtn = (char **)rtalloc(sizeof(char *));
 		}
-		else {
-			rtn = (char **) rtrealloc(rtn, (*n + 1) * sizeof(char *));
+		else
+		{
+			rtn = (char **)rtrealloc(rtn, (*n + 1) * sizeof(char *));
 		}
-		if (NULL == rtn) {
+		if (NULL == rtn)
+		{
 			rterror(_("strsplit: Not enough memory"));
 			return NULL;
 		}
 
 		rtn[*n] = NULL;
-		rtn[*n] = (char *) rtalloc(sizeof(char) * (strlen(token) + 1));
-		if (NULL == rtn[*n]) {
+		rtn[*n] = (char *)rtalloc(sizeof(char) * (strlen(token) + 1));
+		if (NULL == rtn[*n])
+		{
 			rterror(_("strsplit: Not enough memory"));
 			return NULL;
 		}
@@ -270,8 +292,9 @@ strsplit(const char *str, const char *delimiter, uint32_t *n) {
 	return rtn;
 }
 
-static char*
-trim(const char *input) {
+static char *
+trim(const char *input)
+{
 	char *rtn;
 	char *ptr;
 	uint32_t offset = 0;
@@ -280,20 +303,21 @@ trim(const char *input) {
 	if (!input)
 		return NULL;
 	else if (!*input)
-		return (char *) input;
+		return (char *)input;
 
 	/* trim left */
 	while (isspace(*input))
 		input++;
 
 	/* trim right */
-	ptr = ((char *) input) + strlen(input);
+	ptr = ((char *)input) + strlen(input);
 	while (isspace(*--ptr))
 		offset++;
 
 	len = strlen(input) - offset + 1;
 	rtn = rtalloc(sizeof(char) * len);
-	if (NULL == rtn) {
+	if (NULL == rtn)
+	{
 		rterror(_("trim: Not enough memory"));
 		return NULL;
 	}
@@ -302,8 +326,9 @@ trim(const char *input) {
 	return rtn;
 }
 
-static char*
-chartrim(const char *input, char *remove) {
+static char *
+chartrim(const char *input, char *remove)
+{
 	char *rtn = NULL;
 	char *ptr = NULL;
 	uint32_t offset = 0;
@@ -312,20 +337,21 @@ chartrim(const char *input, char *remove) {
 	if (!input)
 		return NULL;
 	else if (!*input)
-		return (char *) input;
+		return (char *)input;
 
 	/* trim left */
 	while (strchr(remove, *input) != NULL)
 		input++;
 
 	/* trim right */
-	ptr = ((char *) input) + strlen(input);
+	ptr = ((char *)input) + strlen(input);
 	while (strchr(remove, *--ptr) != NULL)
 		offset++;
 
 	len = strlen(input) - offset + 1;
 	rtn = rtalloc(sizeof(char) * len);
-	if (NULL == rtn) {
+	if (NULL == rtn)
+	{
 		rterror(_("chartrim: Not enough memory"));
 		return NULL;
 	}
@@ -336,14 +362,15 @@ chartrim(const char *input, char *remove) {
 }
 
 static void
-usage() {
-	printf(_("RELEASE: %s GDAL_VERSION=%d (%s)\n"), POSTGIS_LIB_VERSION, POSTGIS_GDAL_VERSION, xstr(POSTGIS_REVISION));
-	printf(_(
-		"USAGE: raster2pgsql [<options>] <raster>[ <raster>[ ...]] [[<schema>.]<table>]\n"
-		"  Multiple rasters can also be specified using wildcards (*,?).\n"
-		"\n"
-		"OPTIONS:\n"
-	));
+usage()
+{
+	printf(
+	    _("RELEASE: %s GDAL_VERSION=%d (%s)\n"), POSTGIS_LIB_VERSION, POSTGIS_GDAL_VERSION, xstr(POSTGIS_REVISION));
+	printf(
+	    _("USAGE: raster2pgsql [<options>] <raster>[ <raster>[ ...]] [[<schema>.]<table>]\n"
+	      "  Multiple rasters can also be specified using wildcards (*,?).\n"
+	      "\n"
+	      "OPTIONS:\n"));
 	/*
 	printf(_(
 		"  -s [<from>:]<srid> Set the SRID field. Defaults to %d.\n"
@@ -352,116 +379,84 @@ usage() {
 		"     If a srid of %d is provided (either as from or as target).\n"
 	), SRID_UNKNOWN, SRID_UNKNOWN);
 	*/
-	printf(_(
-		"  -s <srid> Set the SRID field. Defaults to %d. If SRID not\n"
-		"     provided or is %d, raster's metadata will be checked to\n"
-		"     determine an appropriate SRID.\n"
-	), SRID_UNKNOWN, SRID_UNKNOWN);
-	printf(_(
-		"  -b <band> Index (1-based) of band to extract from raster. For more\n"
-		"      than one band index, separate with comma (,). Ranges can be\n"
-		"      defined by separating with dash (-). If unspecified, all bands\n"
-		"      of raster will be extracted.\n"
-	));
-	printf(_(
-		"  -t <tile size> Cut raster into tiles to be inserted one per\n"
-		"      table row. <tile size> is expressed as WIDTHxHEIGHT.\n"
-		"      <tile size> can also be \"auto\" to allow the loader to compute\n"
-		"      an appropriate tile size using the first raster and applied to\n"
-		"      all rasters.\n"
-	));
-	printf(_(
-		"  -P Pad right-most and bottom-most tiles to guarantee that all tiles\n"
-		"     have the same width and height.\n"
-	));
-	printf(_(
-		"  -R  Register the raster as an out-of-db (filesystem) raster. Provided\n"
-		"      raster should have absolute path to the file\n"
-	));
-	printf(_(
-		" (-d|a|c|p) These are mutually exclusive options:\n"
-		"     -d  Drops the table, then recreates it and populates\n"
-		"         it with current raster data.\n"
-		"     -a  Appends raster into current table, must be\n"
-		"         exactly the same table schema.\n"
-		"     -c  Creates a new table and populates it, this is the\n"
-		"         default if you do not specify any options.\n"
-		"     -p  Prepare mode, only creates the table.\n"
-	));
-	printf(_(
-		"  -f <column> Specify the name of the raster column\n"
-	));
-	printf(_(
-		"  -F  Add a column with the filename of the raster.\n"
-	));
-	printf(_(
-		"  -n <column> Specify the name of the filename column. Implies -F.\n"
-	));
-	printf(_(
-		"  -l <overview factor> Create overview of the raster. For more than\n"
-		"      one factor, separate with comma(,). Overview table name follows\n"
-		"      the pattern o_<overview factor>_<table>. Created overview is\n"
-		"      stored in the database and is not affected by -R.\n"
-	));
-	printf(_(
-		"  -q  Wrap PostgreSQL identifiers in quotes.\n"
-	));
-	printf(_(
-		"  -I  Create a GIST spatial index on the raster column. The ANALYZE\n"
-		"      command will automatically be issued for the created index.\n"
-	));
-	printf(_(
-		"  -M  Run VACUUM ANALYZE on the table of the raster column. Most\n"
-		"      useful when appending raster to existing table with -a.\n"
-	));
-	printf(_(
-		"  -C  Set the standard set of constraints on the raster\n"
-		"      column after the rasters are loaded. Some constraints may fail\n"
-		"      if one or more rasters violate the constraint.\n"
-		"  -x  Disable setting the max extent constraint. Only applied if\n"
-		"      -C flag is also used.\n"
-		"  -r  Set the constraints (spatially unique and coverage tile) for\n"
-		"      regular blocking. Only applied if -C flag is also used.\n"
-	));
-	printf(_(
-		"  -T <tablespace> Specify the tablespace for the new table.\n"
-		"      Note that indices (including the primary key) will still use\n"
-		"      the default tablespace unless the -X flag is also used.\n"
-	));
-	printf(_(
-		"  -X <tablespace> Specify the tablespace for the table's new index.\n"
-		"      This applies to the primary key and the spatial index if\n"
-		"      the -I flag is used.\n"
-	));
-	printf(_(
-		"  -N <nodata> NODATA value to use on bands without a NODATA value.\n"
-	));
-	printf(_(
-		"  -k  Keep empty tiles by skipping NODATA value checks for each raster band. \n"
-	));
-	printf(_(
-		"  -E <endian> Control endianness of generated binary output of\n"
-		"      raster. Use 0 for XDR and 1 for NDR (default). Only NDR\n"
-		"      is supported at this time.\n"
-	));
-	printf(_(
-		"  -V <version> Specify version of output WKB format. Default\n"
-		"      is 0. Only 0 is supported at this time.\n"
-	));
-	printf(_(
-		"  -e  Execute each statement individually, do not use a transaction.\n"
-	));
-	printf(_(
-		"  -Y <max_rows_per_copy> Use COPY statements instead of INSERT statements. \n"
-		"    Optionally specify <max_rows_per_copy>; default 50 when not specified. \n"
-	));
+	printf(_("  -s <srid> Set the SRID field. Defaults to %d. If SRID not\n"
+		 "     provided or is %d, raster's metadata will be checked to\n"
+		 "     determine an appropriate SRID.\n"),
+	       SRID_UNKNOWN,
+	       SRID_UNKNOWN);
+	printf(
+	    _("  -b <band> Index (1-based) of band to extract from raster. For more\n"
+	      "      than one band index, separate with comma (,). Ranges can be\n"
+	      "      defined by separating with dash (-). If unspecified, all bands\n"
+	      "      of raster will be extracted.\n"));
+	printf(
+	    _("  -t <tile size> Cut raster into tiles to be inserted one per\n"
+	      "      table row. <tile size> is expressed as WIDTHxHEIGHT.\n"
+	      "      <tile size> can also be \"auto\" to allow the loader to compute\n"
+	      "      an appropriate tile size using the first raster and applied to\n"
+	      "      all rasters.\n"));
+	printf(
+	    _("  -P Pad right-most and bottom-most tiles to guarantee that all tiles\n"
+	      "     have the same width and height.\n"));
+	printf(
+	    _("  -R  Register the raster as an out-of-db (filesystem) raster. Provided\n"
+	      "      raster should have absolute path to the file\n"));
+	printf(
+	    _(" (-d|a|c|p) These are mutually exclusive options:\n"
+	      "     -d  Drops the table, then recreates it and populates\n"
+	      "         it with current raster data.\n"
+	      "     -a  Appends raster into current table, must be\n"
+	      "         exactly the same table schema.\n"
+	      "     -c  Creates a new table and populates it, this is the\n"
+	      "         default if you do not specify any options.\n"
+	      "     -p  Prepare mode, only creates the table.\n"));
+	printf(_("  -f <column> Specify the name of the raster column\n"));
+	printf(_("  -F  Add a column with the filename of the raster.\n"));
+	printf(_("  -n <column> Specify the name of the filename column. Implies -F.\n"));
+	printf(
+	    _("  -l <overview factor> Create overview of the raster. For more than\n"
+	      "      one factor, separate with comma(,). Overview table name follows\n"
+	      "      the pattern o_<overview factor>_<table>. Created overview is\n"
+	      "      stored in the database and is not affected by -R.\n"));
+	printf(_("  -q  Wrap PostgreSQL identifiers in quotes.\n"));
+	printf(
+	    _("  -I  Create a GIST spatial index on the raster column. The ANALYZE\n"
+	      "      command will automatically be issued for the created index.\n"));
+	printf(
+	    _("  -M  Run VACUUM ANALYZE on the table of the raster column. Most\n"
+	      "      useful when appending raster to existing table with -a.\n"));
+	printf(
+	    _("  -C  Set the standard set of constraints on the raster\n"
+	      "      column after the rasters are loaded. Some constraints may fail\n"
+	      "      if one or more rasters violate the constraint.\n"
+	      "  -x  Disable setting the max extent constraint. Only applied if\n"
+	      "      -C flag is also used.\n"
+	      "  -r  Set the constraints (spatially unique and coverage tile) for\n"
+	      "      regular blocking. Only applied if -C flag is also used.\n"));
+	printf(
+	    _("  -T <tablespace> Specify the tablespace for the new table.\n"
+	      "      Note that indices (including the primary key) will still use\n"
+	      "      the default tablespace unless the -X flag is also used.\n"));
+	printf(
+	    _("  -X <tablespace> Specify the tablespace for the table's new index.\n"
+	      "      This applies to the primary key and the spatial index if\n"
+	      "      the -I flag is used.\n"));
+	printf(_("  -N <nodata> NODATA value to use on bands without a NODATA value.\n"));
+	printf(_("  -k  Keep empty tiles by skipping NODATA value checks for each raster band. \n"));
+	printf(
+	    _("  -E <endian> Control endianness of generated binary output of\n"
+	      "      raster. Use 0 for XDR and 1 for NDR (default). Only NDR\n"
+	      "      is supported at this time.\n"));
+	printf(
+	    _("  -V <version> Specify version of output WKB format. Default\n"
+	      "      is 0. Only 0 is supported at this time.\n"));
+	printf(_("  -e  Execute each statement individually, do not use a transaction.\n"));
+	printf(
+	    _("  -Y <max_rows_per_copy> Use COPY statements instead of INSERT statements. \n"
+	      "    Optionally specify <max_rows_per_copy>; default 50 when not specified. \n"));
 
-	printf(_(
-		"  -G  Print the supported GDAL raster formats.\n"
-	));
-	printf(_(
-		"  -?  Display this help screen.\n"
-	));
+	printf(_("  -G  Print the supported GDAL raster formats.\n"));
+	printf(_("  -?  Display this help screen.\n"));
 }
 
 static void
@@ -497,7 +492,8 @@ calc_tile_size(uint32_t dimX, uint32_t dimY, int *tileX, int *tileY)
 }
 
 static void
-init_rastinfo(RASTERINFO *info) {
+init_rastinfo(RASTERINFO *info)
+{
 	info->srid = SRID_UNKNOWN;
 	info->srs = NULL;
 	memset(info->dim, 0, sizeof(uint32_t) * 2);
@@ -512,7 +508,8 @@ init_rastinfo(RASTERINFO *info) {
 }
 
 static void
-rtdealloc_rastinfo(RASTERINFO *info) {
+rtdealloc_rastinfo(RASTERINFO *info)
+{
 	if (info->srs != NULL)
 		rtdealloc(info->srs);
 	if (info->nband_count > 0 && info->nband != NULL)
@@ -528,10 +525,13 @@ rtdealloc_rastinfo(RASTERINFO *info) {
 }
 
 static int
-copy_rastinfo(RASTERINFO *dst, RASTERINFO *src) {
-	if (src->srs != NULL) {
+copy_rastinfo(RASTERINFO *dst, RASTERINFO *src)
+{
+	if (src->srs != NULL)
+	{
 		dst->srs = rtalloc(sizeof(char) * (strlen(src->srs) + 1));
-		if (dst->srs == NULL) {
+		if (dst->srs == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
@@ -539,41 +539,51 @@ copy_rastinfo(RASTERINFO *dst, RASTERINFO *src) {
 	}
 	memcpy(dst->dim, src->dim, sizeof(uint32_t) * 2);
 	dst->nband_count = src->nband_count;
-	if (src->nband_count && src->nband != NULL) {
+	if (src->nband_count && src->nband != NULL)
+	{
 		dst->nband = rtalloc(sizeof(int) * src->nband_count);
-		if (dst->nband == NULL) {
+		if (dst->nband == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
 		memcpy(dst->nband, src->nband, sizeof(int) * src->nband_count);
 	}
-	if (src->gdalbandtype != NULL) {
+	if (src->gdalbandtype != NULL)
+	{
 		dst->gdalbandtype = rtalloc(sizeof(GDALDataType) * src->nband_count);
-		if (dst->gdalbandtype == NULL) {
+		if (dst->gdalbandtype == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
 		memcpy(dst->gdalbandtype, src->gdalbandtype, sizeof(GDALDataType) * src->nband_count);
 	}
-	if (src->bandtype != NULL) {
+	if (src->bandtype != NULL)
+	{
 		dst->bandtype = rtalloc(sizeof(rt_pixtype) * src->nband_count);
-		if (dst->bandtype == NULL) {
+		if (dst->bandtype == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
 		memcpy(dst->bandtype, src->bandtype, sizeof(rt_pixtype) * src->nband_count);
 	}
-	if (src->hasnodata != NULL) {
+	if (src->hasnodata != NULL)
+	{
 		dst->hasnodata = rtalloc(sizeof(int) * src->nband_count);
-		if (dst->hasnodata == NULL) {
+		if (dst->hasnodata == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
 		memcpy(dst->hasnodata, src->hasnodata, sizeof(int) * src->nband_count);
 	}
-	if (src->nodataval != NULL) {
+	if (src->nodataval != NULL)
+	{
 		dst->nodataval = rtalloc(sizeof(double) * src->nband_count);
-		if (dst->nodataval == NULL) {
+		if (dst->nodataval == NULL)
+		{
 			rterror(_("copy_rastinfo: Not enough memory"));
 			return 0;
 		}
@@ -586,64 +596,80 @@ copy_rastinfo(RASTERINFO *dst, RASTERINFO *src) {
 }
 
 static void
-diff_rastinfo(RASTERINFO *x, RASTERINFO *ref) {
+diff_rastinfo(RASTERINFO *x, RASTERINFO *ref)
+{
 	static uint8_t msg[6] = {0};
 	uint32_t i = 0;
 
 	/* # of bands */
-	if (
-		!msg[0] &&
-		x->nband_count != ref->nband_count
-	) {
+	if (!msg[0] && x->nband_count != ref->nband_count)
+	{
 		rtwarn(_("Different number of bands found in the set of rasters being converted to PostGIS raster"));
 		msg[0]++;
 	}
 
 	/* pixel types */
-	if (!msg[1]) {
-		for (i = 0; i < ref->nband_count; i++) {
-			if (x->bandtype[i] != ref->bandtype[i]) {
-				rtwarn(_("Different pixel types found for band %d in the set of rasters being converted to PostGIS raster"), ref->nband[i]);
+	if (!msg[1])
+	{
+		for (i = 0; i < ref->nband_count; i++)
+		{
+			if (x->bandtype[i] != ref->bandtype[i])
+			{
+				rtwarn(
+				    _("Different pixel types found for band %d in the set of rasters being converted to PostGIS raster"),
+				    ref->nband[i]);
 				msg[1]++;
 			}
 		}
 	}
 
 	/* hasnodata */
-	if (!msg[2]) {
-		for (i = 0; i < ref->nband_count; i++) {
-			if (x->hasnodata[i] != ref->hasnodata[i]) {
-				rtwarn(_("Different hasnodata flags found for band %d in the set of rasters being converted to PostGIS raster"), ref->nband[i]);
+	if (!msg[2])
+	{
+		for (i = 0; i < ref->nband_count; i++)
+		{
+			if (x->hasnodata[i] != ref->hasnodata[i])
+			{
+				rtwarn(
+				    _("Different hasnodata flags found for band %d in the set of rasters being converted to PostGIS raster"),
+				    ref->nband[i]);
 				msg[2]++;
 			}
 		}
 	}
 
 	/* nodataval */
-	if (!msg[3]) {
-		for (i = 0; i < ref->nband_count; i++) {
-			if (!x->hasnodata[i] && !ref->hasnodata[i]) continue;
-			if (x->hasnodata[i] != ref->hasnodata[i]) {
-				rtwarn(_("Different NODATA values found for band %d in the set of rasters being converted to PostGIS raster"), ref->nband[i]);
+	if (!msg[3])
+	{
+		for (i = 0; i < ref->nband_count; i++)
+		{
+			if (!x->hasnodata[i] && !ref->hasnodata[i])
+				continue;
+			if (x->hasnodata[i] != ref->hasnodata[i])
+			{
+				rtwarn(
+				    _("Different NODATA values found for band %d in the set of rasters being converted to PostGIS raster"),
+				    ref->nband[i]);
 				msg[3]++;
 			}
 		}
 	}
 
 	/* alignment */
-	if (!msg[4]) {
+	if (!msg[4])
+	{
 		rt_raster rx = NULL;
 		rt_raster rref = NULL;
 		int err;
 		int aligned;
 
-		if (
-			(rx = rt_raster_new(1, 1)) == NULL ||
-			(rref = rt_raster_new(1, 1)) == NULL
-		) {
+		if ((rx = rt_raster_new(1, 1)) == NULL || (rref = rt_raster_new(1, 1)) == NULL)
+		{
 			rterror(_("diff_rastinfo: Could not allocate memory for raster alignment test"));
-			if (rx != NULL) rt_raster_destroy(rx);
-			if (rref != NULL) rt_raster_destroy(rref);
+			if (rx != NULL)
+				rt_raster_destroy(rx);
+			if (rref != NULL)
+				rt_raster_destroy(rref);
 			return;
 		}
 
@@ -653,22 +679,29 @@ diff_rastinfo(RASTERINFO *x, RASTERINFO *ref) {
 		err = rt_raster_same_alignment(rx, rref, &aligned, NULL);
 		rt_raster_destroy(rx);
 		rt_raster_destroy(rref);
-		if (err != ES_NONE) {
+		if (err != ES_NONE)
+		{
 			rterror(_("diff_rastinfo: Could not run raster alignment test"));
 			return;
 		}
 
-		if (!aligned) {
-			rtwarn(_("Raster with different alignment found in the set of rasters being converted to PostGIS raster"));
+		if (!aligned)
+		{
+			rtwarn(_(
+			    "Raster with different alignment found in the set of rasters being converted to PostGIS raster"));
 			msg[4]++;
 		}
 	}
 
 	/* tile size */
-	if (!msg[5]) {
-		for (i = 0; i < 2; i++) {
-			if (x->tile_size[i] != ref->tile_size[i]) {
-				rtwarn(_("Different tile sizes found in the set of rasters being converted to PostGIS raster"));
+	if (!msg[5])
+	{
+		for (i = 0; i < 2; i++)
+		{
+			if (x->tile_size[i] != ref->tile_size[i])
+			{
+				rtwarn(_(
+				    "Different tile sizes found in the set of rasters being converted to PostGIS raster"));
 				msg[5]++;
 				break;
 			}
@@ -677,7 +710,8 @@ diff_rastinfo(RASTERINFO *x, RASTERINFO *ref) {
 }
 
 static void
-init_config(RTLOADERCFG *config) {
+init_config(RTLOADERCFG *config)
+{
 	config->rt_file_count = 0;
 	config->rt_file = NULL;
 	config->rt_filename = NULL;
@@ -715,10 +749,13 @@ init_config(RTLOADERCFG *config) {
 }
 
 static void
-rtdealloc_config(RTLOADERCFG *config) {
+rtdealloc_config(RTLOADERCFG *config)
+{
 	int i = 0;
-	if (config->rt_file_count) {
-		for (i = config->rt_file_count - 1; i >= 0; i--) {
+	if (config->rt_file_count)
+	{
+		for (i = config->rt_file_count - 1; i >= 0; i--)
+		{
 			rtdealloc(config->rt_file[i]);
 			if (config->rt_filename)
 				rtdealloc(config->rt_filename[i]);
@@ -735,10 +772,12 @@ rtdealloc_config(RTLOADERCFG *config) {
 		rtdealloc(config->raster_column);
 	if (config->file_column_name != NULL)
 		rtdealloc(config->file_column_name);
-	if (config->overview_count > 0) {
+	if (config->overview_count > 0)
+	{
 		if (config->overview != NULL)
 			rtdealloc(config->overview);
-		if (config->overview_table != NULL) {
+		if (config->overview_table != NULL)
+		{
 			for (i = config->overview_count - 1; i >= 0; i--)
 				rtdealloc(config->overview_table[i]);
 			rtdealloc(config->overview_table);
@@ -755,16 +794,20 @@ rtdealloc_config(RTLOADERCFG *config) {
 }
 
 static void
-init_stringbuffer(STRINGBUFFER *buffer) {
+init_stringbuffer(STRINGBUFFER *buffer)
+{
 	buffer->line = NULL;
 	buffer->length = 0;
 }
 
 static void
-rtdealloc_stringbuffer(STRINGBUFFER *buffer, int freebuffer) {
-	if (buffer->length) {
+rtdealloc_stringbuffer(STRINGBUFFER *buffer, int freebuffer)
+{
+	if (buffer->length)
+	{
 		uint32_t i = 0;
-		for (i = 0; i < buffer->length; i++) {
+		for (i = 0; i < buffer->length; i++)
+		{
 			if (buffer->line[i] != NULL)
 				rtdealloc(buffer->line[i]);
 		}
@@ -778,38 +821,44 @@ rtdealloc_stringbuffer(STRINGBUFFER *buffer, int freebuffer) {
 }
 
 static void
-dump_stringbuffer(STRINGBUFFER *buffer) {
+dump_stringbuffer(STRINGBUFFER *buffer)
+{
 	uint32_t i = 0;
 
-	for (i = 0; i < buffer->length; i++) {
+	for (i = 0; i < buffer->length; i++)
+	{
 		printf("%s\n", buffer->line[i]);
 	}
 }
 
 static void
-flush_stringbuffer(STRINGBUFFER *buffer) {
+flush_stringbuffer(STRINGBUFFER *buffer)
+{
 	dump_stringbuffer(buffer);
 	rtdealloc_stringbuffer(buffer, 0);
 }
 
 /* Takes ownership of the passed string */
 static int
-append_stringbuffer(STRINGBUFFER *buffer, const char *str) {
+append_stringbuffer(STRINGBUFFER *buffer, const char *str)
+{
 	buffer->length++;
 
 	buffer->line = rtrealloc(buffer->line, sizeof(char *) * buffer->length);
-	if (buffer->line == NULL) {
+	if (buffer->line == NULL)
+	{
 		rterror(_("append_stringbuffer: Could not allocate memory for appending string to buffer"));
 		return 0;
 	}
 
-	buffer->line[buffer->length - 1] = (char *) str;
+	buffer->line[buffer->length - 1] = (char *)str;
 
 	return 1;
 }
 
 static int
-append_sql_to_buffer(STRINGBUFFER *buffer, const char *str) {
+append_sql_to_buffer(STRINGBUFFER *buffer, const char *str)
+{
 	if (buffer->length > 9)
 		flush_stringbuffer(buffer);
 
@@ -817,9 +866,12 @@ append_sql_to_buffer(STRINGBUFFER *buffer, const char *str) {
 }
 
 static int
-copy_from(const char *schema, const char *table, const char *column,
-          const char *filename, const char *file_column_name,
-          STRINGBUFFER *buffer)
+copy_from(const char *schema,
+	  const char *table,
+	  const char *column,
+	  const char *filename,
+	  const char *file_column_name,
+	  STRINGBUFFER *buffer)
 {
 	char *sql = NULL;
 	uint32_t len = 0;
@@ -836,17 +888,18 @@ copy_from(const char *schema, const char *table, const char *column,
 		len += strlen(",") + strlen(file_column_name);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("copy_from: Could not allocate memory for COPY statement"));
 		return 0;
 	}
-	sprintf(sql, "COPY %s%s (%s%s%s) FROM stdin;",
+	sprintf(sql,
+		"COPY %s%s (%s%s%s) FROM stdin;",
 		(schema != NULL ? schema : ""),
 		table,
 		column,
 		(filename != NULL ? "," : ""),
-		(filename != NULL ? file_column_name : "")
-	);
+		(filename != NULL ? file_column_name : ""));
 
 	append_sql_to_buffer(buffer, sql);
 	sql = NULL;
@@ -867,12 +920,16 @@ copy_from_end(STRINGBUFFER *buffer)
 }
 
 static int
-insert_records(
-	const char *schema, const char *table, const char *column,
-	const char *filename, const char *file_column_name,
-	int copy_statements, int out_srid,
-	STRINGBUFFER *tileset, STRINGBUFFER *buffer
-) {
+insert_records(const char *schema,
+	       const char *table,
+	       const char *column,
+	       const char *filename,
+	       const char *file_column_name,
+	       int copy_statements,
+	       int out_srid,
+	       STRINGBUFFER *tileset,
+	       STRINGBUFFER *buffer)
+{
 	char *fn = NULL;
 	uint32_t len = 0;
 	char *sql = NULL;
@@ -882,52 +939,52 @@ insert_records(
 	assert(column != NULL);
 
 	/* COPY statements */
-	if (copy_statements) {
+	if (copy_statements)
+	{
 
-    if (!copy_from(
-      schema, table, column,
-      (file_column_name ? filename : NULL), file_column_name,
-      buffer
-    )) {
-      rterror(_("insert_records: Could not add COPY statement to string buffer"));
-      return 0;
-    }
-
+		if (!copy_from(schema, table, column, (file_column_name ? filename : NULL), file_column_name, buffer))
+		{
+			rterror(_("insert_records: Could not add COPY statement to string buffer"));
+			return 0;
+		}
 
 		/* escape tabs in filename */
 		if (filename != NULL)
 			fn = strreplace(filename, "\t", "\\t", NULL);
 
 		/* rows */
-		for (x = 0; x < tileset->length; x++) {
+		for (x = 0; x < tileset->length; x++)
+		{
 			len = strlen(tileset->line[x]) + 1;
 
 			if (filename != NULL)
 				len += strlen(fn) + 1;
 
 			sql = rtalloc(sizeof(char) * len);
-			if (sql == NULL) {
+			if (sql == NULL)
+			{
 				rterror(_("insert_records: Could not allocate memory for COPY statement"));
 				return 0;
 			}
-			sprintf(sql, "%s%s%s",
+			sprintf(sql,
+				"%s%s%s",
 				tileset->line[x],
 				(filename != NULL ? "\t" : ""),
-				(filename != NULL ? fn : "")
-			);
+				(filename != NULL ? fn : ""));
 
 			append_sql_to_buffer(buffer, sql);
 			sql = NULL;
 		}
 
-    if (!copy_from_end(buffer)) {
-      rterror(_("process_rasters: Could not add COPY end statement to string buffer"));
-      return 0;
-    }
-
+		if (!copy_from_end(buffer))
+		{
+			rterror(_("process_rasters: Could not add COPY end statement to string buffer"));
+			return 0;
+		}
 	}
 	/* INSERT statements */
-	else {
+	else
+	{
 		len = strlen("INSERT INTO  () VALUES (ST_Transform(''::raster,xxxxxxxxx));") + 1;
 		if (schema != NULL)
 			len += strlen(schema);
@@ -940,7 +997,8 @@ insert_records(
 		if (filename != NULL)
 			fn = strreplace(filename, "'", "''", NULL);
 
-		for (x = 0; x < tileset->length; x++) {
+		for (x = 0; x < tileset->length; x++)
+		{
 			char *ptr;
 			int sqllen = len;
 
@@ -949,28 +1007,30 @@ insert_records(
 				sqllen += strlen(",''") + strlen(fn);
 
 			sql = rtalloc(sizeof(char) * sqllen);
-			if (sql == NULL) {
+			if (sql == NULL)
+			{
 				rterror(_("insert_records: Could not allocate memory for INSERT statement"));
 				return 0;
 			}
 			ptr = sql;
-			ptr += sprintf(sql, "INSERT INTO %s%s (%s%s%s) VALUES (",
-					(schema != NULL ? schema : ""),
-					table,
-					column,
-					(filename != NULL ? "," : ""),
-					(filename != NULL ? file_column_name : "")
-				);
-			if (out_srid != SRID_UNKNOWN) {
+			ptr += sprintf(sql,
+				       "INSERT INTO %s%s (%s%s%s) VALUES (",
+				       (schema != NULL ? schema : ""),
+				       table,
+				       column,
+				       (filename != NULL ? "," : ""),
+				       (filename != NULL ? file_column_name : ""));
+			if (out_srid != SRID_UNKNOWN)
+			{
 				ptr += sprintf(ptr, "ST_Transform(");
 			}
-			ptr += sprintf(ptr, "'%s'::raster",
-					tileset->line[x]
-				);
-			if (out_srid != SRID_UNKNOWN) {
+			ptr += sprintf(ptr, "'%s'::raster", tileset->line[x]);
+			if (out_srid != SRID_UNKNOWN)
+			{
 				ptr += sprintf(ptr, ", %d)", out_srid);
 			}
-			if (filename != NULL) {
+			if (filename != NULL)
+			{
 				ptr += sprintf(ptr, ",'%s'", fn);
 			}
 			ptr += sprintf(ptr, ");");
@@ -980,12 +1040,14 @@ insert_records(
 		}
 	}
 
-	if (fn != NULL) rtdealloc(fn);
+	if (fn != NULL)
+		rtdealloc(fn);
 	return 1;
 }
 
 static int
-drop_table(const char *schema, const char *table, STRINGBUFFER *buffer) {
+drop_table(const char *schema, const char *table, STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -995,14 +1057,12 @@ drop_table(const char *schema, const char *table, STRINGBUFFER *buffer) {
 	len += strlen(table);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("drop_table: Could not allocate memory for DROP TABLE statement"));
 		return 0;
 	}
-	sprintf(sql, "DROP TABLE IF EXISTS %s%s;",
-		(schema != NULL ? schema : ""),
-		table
-	);
+	sprintf(sql, "DROP TABLE IF EXISTS %s%s;", (schema != NULL ? schema : ""), table);
 
 	append_sql_to_buffer(buffer, sql);
 
@@ -1010,12 +1070,15 @@ drop_table(const char *schema, const char *table, STRINGBUFFER *buffer) {
 }
 
 static int
-create_table(
-	const char *schema, const char *table, const char *column,
-	const int file_column, const char *file_column_name,
-	const char *tablespace, const char *idx_tablespace,
-	STRINGBUFFER *buffer
-) {
+create_table(const char *schema,
+	     const char *table,
+	     const char *column,
+	     const int file_column,
+	     const char *file_column_name,
+	     const char *tablespace,
+	     const char *idx_tablespace,
+	     STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -1035,11 +1098,13 @@ create_table(
 		len += strlen(" USING INDEX TABLESPACE ") + strlen(idx_tablespace);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("create_table: Could not allocate memory for CREATE TABLE statement"));
 		return 0;
 	}
-	sprintf(sql, "CREATE TABLE %s%s (\"rid\" serial PRIMARY KEY%s%s,%s raster%s%s%s)%s%s;",
+	sprintf(sql,
+		"CREATE TABLE %s%s (\"rid\" serial PRIMARY KEY%s%s,%s raster%s%s%s)%s%s;",
 		(schema != NULL ? schema : ""),
 		table,
 		(idx_tablespace != NULL ? " USING INDEX TABLESPACE " : ""),
@@ -1049,8 +1114,7 @@ create_table(
 		(file_column ? file_column_name : ""),
 		(file_column ? " text" : ""),
 		(tablespace != NULL ? " TABLESPACE " : ""),
-		(tablespace != NULL ? tablespace : "")
-	);
+		(tablespace != NULL ? tablespace : ""));
 
 	append_sql_to_buffer(buffer, sql);
 
@@ -1058,11 +1122,8 @@ create_table(
 }
 
 static int
-create_index(
-	const char *schema, const char *table, const char *column,
-	const char *tablespace,
-	STRINGBUFFER *buffer
-) {
+create_index(const char *schema, const char *table, const char *column, const char *tablespace, STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 	char *_table = NULL;
@@ -1086,19 +1147,20 @@ create_index(
 		len += strlen(" TABLESPACE ") + strlen(tablespace);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("create_index: Could not allocate memory for CREATE INDEX statement"));
 		rtdealloc(_table);
 		rtdealloc(_column);
 		return 0;
 	}
-	sprintf(sql, "CREATE INDEX ON %s%s USING gist (st_convexhull(%s))%s%s;",
+	sprintf(sql,
+		"CREATE INDEX ON %s%s USING gist (st_convexhull(%s))%s%s;",
 		(schema != NULL ? schema : ""),
 		table,
 		column,
 		(tablespace != NULL ? " TABLESPACE " : ""),
-		(tablespace != NULL ? tablespace : "")
-	);
+		(tablespace != NULL ? tablespace : ""));
 	rtdealloc(_table);
 	rtdealloc(_column);
 
@@ -1108,10 +1170,8 @@ create_index(
 }
 
 static int
-analyze_table(
-	const char *schema, const char *table,
-	STRINGBUFFER *buffer
-) {
+analyze_table(const char *schema, const char *table, STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -1123,14 +1183,12 @@ analyze_table(
 	len += strlen(table);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("analyze_table: Could not allocate memory for ANALYZE TABLE statement"));
 		return 0;
 	}
-	sprintf(sql, "ANALYZE %s%s;",
-		(schema != NULL ? schema : ""),
-		table
-	);
+	sprintf(sql, "ANALYZE %s%s;", (schema != NULL ? schema : ""), table);
 
 	append_sql_to_buffer(buffer, sql);
 
@@ -1138,10 +1196,8 @@ analyze_table(
 }
 
 static int
-vacuum_table(
-	const char *schema, const char *table,
-	STRINGBUFFER *buffer
-) {
+vacuum_table(const char *schema, const char *table, STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -1153,14 +1209,12 @@ vacuum_table(
 	len += strlen(table);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("vacuum_table: Could not allocate memory for VACUUM statement"));
 		return 0;
 	}
-	sprintf(sql, "VACUUM ANALYZE %s%s;",
-		(schema != NULL ? schema : ""),
-		table
-	);
+	sprintf(sql, "VACUUM ANALYZE %s%s;", (schema != NULL ? schema : ""), table);
 
 	append_sql_to_buffer(buffer, sql);
 
@@ -1168,11 +1222,13 @@ vacuum_table(
 }
 
 static int
-add_raster_constraints(
-	const char *schema, const char *table, const char *column,
-	int regular_blocking, int max_extent,
-	STRINGBUFFER *buffer
-) {
+add_raster_constraints(const char *schema,
+		       const char *table,
+		       const char *column,
+		       int regular_blocking,
+		       int max_extent,
+		       STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -1185,7 +1241,8 @@ add_raster_constraints(
 	assert(column != NULL);
 
 	/* schema */
-	if (schema != NULL) {
+	if (schema != NULL)
+	{
 		_tmp = chartrim(schema, ".");
 		_schema = chartrim(_tmp, "\"");
 		rtdealloc(_tmp);
@@ -1204,24 +1261,28 @@ add_raster_constraints(
 	_column = strreplace(_tmp, "'", "''", NULL);
 	rtdealloc(_tmp);
 
-	len = strlen("SELECT AddRasterConstraints('','','',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE);") + 1;
+	len =
+	    strlen(
+		"SELECT AddRasterConstraints('','','',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE);") +
+	    1;
 	if (_schema != NULL)
 		len += strlen(_schema);
 	len += strlen(_table);
 	len += strlen(_column);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("add_raster_constraints: Could not allocate memory for AddRasterConstraints statement"));
 		return 0;
 	}
-	sprintf(sql, "SELECT AddRasterConstraints('%s','%s','%s',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,%s,TRUE,TRUE,TRUE,TRUE,%s);",
+	sprintf(sql,
+		"SELECT AddRasterConstraints('%s','%s','%s',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,%s,TRUE,TRUE,TRUE,TRUE,%s);",
 		(_schema != NULL ? _schema : ""),
 		_table,
 		_column,
 		(regular_blocking ? "TRUE" : "FALSE"),
-		(max_extent ? "TRUE" : "FALSE")
-	);
+		(max_extent ? "TRUE" : "FALSE"));
 
 	if (_schema != NULL)
 		rtdealloc(_schema);
@@ -1234,12 +1295,15 @@ add_raster_constraints(
 }
 
 static int
-add_overview_constraints(
-	const char *ovschema, const char *ovtable, const char *ovcolumn,
-	const char *schema, const char *table, const char *column,
-	const int factor,
-	STRINGBUFFER *buffer
-) {
+add_overview_constraints(const char *ovschema,
+			 const char *ovtable,
+			 const char *ovcolumn,
+			 const char *schema,
+			 const char *table,
+			 const char *column,
+			 const int factor,
+			 STRINGBUFFER *buffer)
+{
 	char *sql = NULL;
 	uint32_t len = 0;
 
@@ -1260,7 +1324,8 @@ add_overview_constraints(
 	assert(factor >= MINOVFACTOR && factor <= MAXOVFACTOR);
 
 	/* overview schema */
-	if (ovschema != NULL) {
+	if (ovschema != NULL)
+	{
 		_tmp = chartrim(ovschema, ".");
 		_ovschema = chartrim(_tmp, "\"");
 		rtdealloc(_tmp);
@@ -1280,7 +1345,8 @@ add_overview_constraints(
 	rtdealloc(_tmp);
 
 	/* schema */
-	if (schema != NULL) {
+	if (schema != NULL)
+	{
 		_tmp = chartrim(schema, ".");
 		_schema = chartrim(_tmp, "\"");
 		rtdealloc(_tmp);
@@ -1310,19 +1376,20 @@ add_overview_constraints(
 	len += strlen(_column);
 
 	sql = rtalloc(sizeof(char) * len);
-	if (sql == NULL) {
+	if (sql == NULL)
+	{
 		rterror(_("add_overview_constraints: Could not allocate memory for AddOverviewConstraints statement"));
 		return 0;
 	}
-	sprintf(sql, "SELECT AddOverviewConstraints('%s','%s','%s','%s','%s','%s',%d);",
+	sprintf(sql,
+		"SELECT AddOverviewConstraints('%s','%s','%s','%s','%s','%s',%d);",
 		(_ovschema != NULL ? _ovschema : ""),
 		_ovtable,
 		_ovcolumn,
 		(_schema != NULL ? _schema : ""),
 		_table,
 		_column,
-		factor
-	);
+		factor);
 
 	if (_ovschema != NULL)
 		rtdealloc(_ovschema);
@@ -1340,7 +1407,13 @@ add_overview_constraints(
 }
 
 static int
-build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STRINGBUFFER *tileset, STRINGBUFFER *buffer) {
+build_overview(int idx,
+	       RTLOADERCFG *config,
+	       RASTERINFO *info,
+	       uint32_t ovx,
+	       STRINGBUFFER *tileset,
+	       STRINGBUFFER *buffer)
+{
 	GDALDatasetH hdsSrc;
 	VRTDatasetH hdsOv;
 	VRTSourcedRasterBandH hbandOv;
@@ -1365,7 +1438,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 	uint32_t hexlen = 0;
 
 	hdsSrc = GDALOpenShared(config->rt_file[idx], GA_ReadOnly);
-	if (hdsSrc == NULL) {
+	if (hdsSrc == NULL)
+	{
 		rterror(_("build_overview: Could not open raster: %s"), config->rt_file[idx]);
 		return 0;
 	}
@@ -1373,21 +1447,24 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 	/* working copy of geotransform matrix */
 	memcpy(gtOv, info->gt, sizeof(double) * 6);
 
-	if (ovx >= config->overview_count) {
+	if (ovx >= config->overview_count)
+	{
 		rterror(_("build_overview: Invalid overview index: %d"), ovx);
 		return 0;
 	}
 	factor = config->overview[ovx];
-	ovtable = (const char *) config->overview_table[ovx];
+	ovtable = (const char *)config->overview_table[ovx];
 
 	/* factor must be within valid range */
-	if (factor < MINOVFACTOR || factor > MAXOVFACTOR) {
-		rterror(_("build_overview: Overview factor %d is not between %d and %d"), factor, MINOVFACTOR, MAXOVFACTOR);
+	if (factor < MINOVFACTOR || factor > MAXOVFACTOR)
+	{
+		rterror(
+		    _("build_overview: Overview factor %d is not between %d and %d"), factor, MINOVFACTOR, MAXOVFACTOR);
 		return 0;
 	}
 
-	dimOv[0] = (int) (info->dim[0] + (factor / 2)) / factor;
-	dimOv[1] = (int) (info->dim[1] + (factor / 2)) / factor;
+	dimOv[0] = (int)(info->dim[0] + (factor / 2)) / factor;
+	dimOv[1] = (int)(info->dim[1] + (factor / 2)) / factor;
 
 	/* create VRT dataset */
 	hdsOv = VRTCreate(dimOv[0], dimOv[1]);
@@ -1403,21 +1480,26 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 	GDALSetGeoTransform(hdsOv, gtOv);
 
 	/* add bands as simple sources */
-	for (j = 0; j < info->nband_count; j++) {
+	for (j = 0; j < info->nband_count; j++)
+	{
 		GDALAddBand(hdsOv, info->gdalbandtype[j], NULL);
-		hbandOv = (VRTSourcedRasterBandH) GDALGetRasterBand(hdsOv, j + 1);
+		hbandOv = (VRTSourcedRasterBandH)GDALGetRasterBand(hdsOv, j + 1);
 
 		if (info->hasnodata[j])
 			GDALSetRasterNoDataValue(hbandOv, info->nodataval[j]);
 
-		VRTAddSimpleSource(
-			hbandOv, GDALGetRasterBand(hdsSrc, info->nband[j]),
-			0, 0,
-			info->dim[0], info->dim[1],
-			0, 0,
-			dimOv[0], dimOv[1],
-			"near", VRT_NODATA_UNSET
-		);
+		VRTAddSimpleSource(hbandOv,
+				   GDALGetRasterBand(hdsSrc, info->nband[j]),
+				   0,
+				   0,
+				   info->dim[0],
+				   info->dim[1],
+				   0,
+				   0,
+				   dimOv[0],
+				   dimOv[1],
+				   "near",
+				   VRT_NODATA_UNSET);
 	}
 
 	/* make sure VRT reflects all changes */
@@ -1434,12 +1516,10 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 		tile_size[1] = config->tile_size[1];
 
 	/* number of tiles */
-	if (
-		tile_size[0] != dimOv[0] &&
-		tile_size[1] != dimOv[1]
-	) {
-		ntiles[0] = (dimOv[0] + tile_size[0] -  1) / tile_size[0];
-		ntiles[1] = (dimOv[1] + tile_size[1]  - 1) / tile_size[1];
+	if (tile_size[0] != dimOv[0] && tile_size[1] != dimOv[1])
+	{
+		ntiles[0] = (dimOv[0] + tile_size[0] - 1) / tile_size[0];
+		ntiles[1] = (dimOv[1] + tile_size[1] - 1) / tile_size[1];
 	}
 
 	/* working copy of geotransform matrix */
@@ -1447,7 +1527,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 
 	/* tile overview */
 	/* each tile is a VRT with constraints set for just the data required for the tile */
-	for (ytile = 0; ytile < ntiles[1]; ytile++) {
+	for (ytile = 0; ytile < ntiles[1]; ytile++)
+	{
 
 		/* edge y tile */
 		if (!config->pad_tile && ntiles[1] > 1 && (ytile + 1) == ntiles[1])
@@ -1455,7 +1536,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 		else
 			_tile_size[1] = tile_size[1];
 
-		for (xtile = 0; xtile < ntiles[0]; xtile++) {
+		for (xtile = 0; xtile < ntiles[0]; xtile++)
+		{
 			/*
 			char fn[100];
 			sprintf(fn, "/tmp/ovtile%d.vrt", (ytile * ntiles[0]) + xtile);
@@ -1468,11 +1550,7 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 				_tile_size[0] = tile_size[0];
 
 			/* compute tile's upper-left corner */
-			GDALApplyGeoTransform(
-				gtOv,
-				xtile * tile_size[0], ytile * tile_size[1],
-				&(gt[0]), &(gt[3])
-			);
+			GDALApplyGeoTransform(gtOv, xtile * tile_size[0], ytile * tile_size[1], &(gt[0]), &(gt[3]));
 
 			/* create VRT dataset */
 			hdsDst = VRTCreate(_tile_size[0], _tile_size[1]);
@@ -1483,21 +1561,26 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 			GDALSetGeoTransform(hdsDst, gt);
 
 			/* add bands as simple sources */
-			for (j = 0; j < info->nband_count; j++) {
+			for (j = 0; j < info->nband_count; j++)
+			{
 				GDALAddBand(hdsDst, info->gdalbandtype[j], NULL);
-				hbandDst = (VRTSourcedRasterBandH) GDALGetRasterBand(hdsDst, j + 1);
+				hbandDst = (VRTSourcedRasterBandH)GDALGetRasterBand(hdsDst, j + 1);
 
 				if (info->hasnodata[j])
 					GDALSetRasterNoDataValue(hbandDst, info->nodataval[j]);
 
-				VRTAddSimpleSource(
-					hbandDst, GDALGetRasterBand(hdsOv, j + 1),
-					xtile * tile_size[0], ytile * tile_size[1],
-					_tile_size[0], _tile_size[1],
-					0, 0,
-					_tile_size[0], _tile_size[1],
-					"near", VRT_NODATA_UNSET
-				);
+				VRTAddSimpleSource(hbandDst,
+						   GDALGetRasterBand(hdsOv, j + 1),
+						   xtile * tile_size[0],
+						   ytile * tile_size[1],
+						   _tile_size[0],
+						   _tile_size[1],
+						   0,
+						   0,
+						   _tile_size[0],
+						   _tile_size[1],
+						   "near",
+						   VRT_NODATA_UNSET);
 			}
 
 			/* make sure VRT reflects all changes */
@@ -1505,7 +1588,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 
 			/* convert VRT dataset to rt_raster */
 			rast = rt_raster_from_gdal_dataset(hdsDst);
-			if (rast == NULL) {
+			if (rast == NULL)
+			{
 				rterror(_("build_overview: Could not convert VRT dataset to PostGIS raster"));
 				GDALClose(hdsDst);
 				return 0;
@@ -1518,7 +1602,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 			hex = rt_raster_to_hexwkb(rast, FALSE, &hexlen);
 			raster_destroy(rast);
 
-			if (hex == NULL) {
+			if (hex == NULL)
+			{
 				rterror(_("build_overview: Could not convert PostGIS raster to hex WKB"));
 				GDALClose(hdsDst);
 				return 0;
@@ -1530,14 +1615,20 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 			GDALClose(hdsDst);
 
 			/* flush if tileset gets too big */
-			if (tileset->length >= config->max_tiles_per_copy) {
-				if (!insert_records(
-					config->schema, ovtable, config->raster_column,
-					(config->file_column ? config->rt_filename[idx] : NULL), config->file_column_name,
-					config->copy_statements, config->out_srid,
-					tileset, buffer
-				)) {
-					rterror(_("build_overview: Could not convert raster tiles into INSERT or COPY statements"));
+			if (tileset->length >= config->max_tiles_per_copy)
+			{
+				if (!insert_records(config->schema,
+						    ovtable,
+						    config->raster_column,
+						    (config->file_column ? config->rt_filename[idx] : NULL),
+						    config->file_column_name,
+						    config->copy_statements,
+						    config->out_srid,
+						    tileset,
+						    buffer))
+				{
+					rterror(_(
+					    "build_overview: Could not convert raster tiles into INSERT or COPY statements"));
 					GDALClose(hdsSrc);
 					return 0;
 				}
@@ -1553,7 +1644,8 @@ build_overview(int idx, RTLOADERCFG *config, RASTERINFO *info, uint32_t ovx, STR
 }
 
 static int
-convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *tileset, STRINGBUFFER *buffer) {
+convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *tileset, STRINGBUFFER *buffer)
+{
 	GDALDatasetH hdsSrc;
 	GDALRasterBandH hbandSrc;
 	int nband = 0;
@@ -1565,7 +1657,7 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 	int naturalx = 1;
 	int naturaly = 1;
 	double gt[6] = {0.};
-	const char* pszProjectionRef = NULL;
+	const char *pszProjectionRef = NULL;
 	int tilesize = 0;
 
 	rt_raster rast = NULL;
@@ -1577,22 +1669,28 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 	info->srid = config->srid;
 
 	hdsSrc = GDALOpenShared(config->rt_file[idx], GA_ReadOnly);
-	if (hdsSrc == NULL) {
+	if (hdsSrc == NULL)
+	{
 		rterror(_("convert_raster: Could not open raster: %s"), config->rt_file[idx]);
 		return 0;
 	}
 
 	nband = GDALGetRasterCount(hdsSrc);
-	if (!nband) {
+	if (!nband)
+	{
 		rterror(_("convert_raster: No bands found in raster: %s"), config->rt_file[idx]);
 		GDALClose(hdsSrc);
 		return 0;
 	}
 
 	/* check that bands specified are available */
-	for (i = 0; i < config->nband_count; i++) {
-		if (config->nband[i] > nband) {
-			rterror(_("convert_raster: Band %d not found in raster: %s"), config->nband[i], config->rt_file[idx]);
+	for (i = 0; i < config->nband_count; i++)
+	{
+		if (config->nband[i] > nband)
+		{
+			rterror(_("convert_raster: Band %d not found in raster: %s"),
+				config->nband[i],
+				config->rt_file[idx]);
 			GDALClose(hdsSrc);
 			return 0;
 		}
@@ -1600,25 +1698,27 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 	/* record srs */
 	pszProjectionRef = GDALGetProjectionRef(hdsSrc);
-	if (pszProjectionRef != NULL && pszProjectionRef[0] != '\0') {
+	if (pszProjectionRef != NULL && pszProjectionRef[0] != '\0')
+	{
 		info->srs = rtalloc(sizeof(char) * (strlen(pszProjectionRef) + 1));
-		if (info->srs == NULL) {
+		if (info->srs == NULL)
+		{
 			rterror(_("convert_raster: Could not allocate memory for storing SRS"));
 			GDALClose(hdsSrc);
 			return 0;
 		}
 		strcpy(info->srs, pszProjectionRef);
 
-		if (info->srid == SRID_UNKNOWN) {
+		if (info->srid == SRID_UNKNOWN)
+		{
 			OGRSpatialReferenceH hSRS = OSRNewSpatialReference(NULL);
-			if (OSRSetFromUserInput(hSRS, pszProjectionRef) == OGRERR_NONE) {
-				const char* pszAuthorityName = OSRGetAuthorityName(hSRS, NULL);
-				const char* pszAuthorityCode = OSRGetAuthorityCode(hSRS, NULL);
-				if (
-					pszAuthorityName != NULL &&
-					strcmp(pszAuthorityName, "EPSG") == 0 &&
-					pszAuthorityCode != NULL
-				) {
+			if (OSRSetFromUserInput(hSRS, pszProjectionRef) == OGRERR_NONE)
+			{
+				const char *pszAuthorityName = OSRGetAuthorityName(hSRS, NULL);
+				const char *pszAuthorityCode = OSRGetAuthorityCode(hSRS, NULL);
+				if (pszAuthorityName != NULL && strcmp(pszAuthorityName, "EPSG") == 0 &&
+				    pszAuthorityCode != NULL)
+				{
 					info->srid = atoi(pszAuthorityCode);
 				}
 			}
@@ -1626,14 +1726,17 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 		}
 	}
 
-	if ( info->srid == SRID_UNKNOWN && config->out_srid != SRID_UNKNOWN ) {
-		  rterror(_("convert_raster: could not determine source srid, cannot transform to target srid %d"), config->out_srid);
-		  GDALClose(hdsSrc);
-		  return 0;
+	if (info->srid == SRID_UNKNOWN && config->out_srid != SRID_UNKNOWN)
+	{
+		rterror(_("convert_raster: could not determine source srid, cannot transform to target srid %d"),
+			config->out_srid);
+		GDALClose(hdsSrc);
+		return 0;
 	}
 
 	/* record geotransform matrix */
-	if (GDALGetGeoTransform(hdsSrc, info->gt) != CE_None) {
+	if (GDALGetGeoTransform(hdsSrc, info->gt) != CE_None)
+	{
 		rtinfo(_("Using default geotransform matrix (0, 1, 0, 0, 0, -1) for raster: %s"), config->rt_file[idx]);
 		info->gt[0] = 0;
 		info->gt[1] = 1;
@@ -1646,10 +1749,12 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 	/* record # of bands */
 	/* user-specified bands */
-	if (config->nband_count > 0) {
+	if (config->nband_count > 0)
+	{
 		info->nband_count = config->nband_count;
 		info->nband = rtalloc(sizeof(int) * info->nband_count);
-		if (info->nband == NULL) {
+		if (info->nband == NULL)
+		{
 			rterror(_("convert_raster: Could not allocate memory for storing band indices"));
 			GDALClose(hdsSrc);
 			return 0;
@@ -1657,10 +1762,12 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 		memcpy(info->nband, config->nband, sizeof(int) * info->nband_count);
 	}
 	/* all bands */
-	else {
+	else
+	{
 		info->nband_count = nband;
 		info->nband = rtalloc(sizeof(int) * info->nband_count);
-		if (info->nband == NULL) {
+		if (info->nband == NULL)
+		{
 			rterror(_("convert_raster: Could not allocate memory for storing band indices"));
 			GDALClose(hdsSrc);
 			return 0;
@@ -1671,25 +1778,29 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 	/* initialize parameters dependent on nband */
 	info->gdalbandtype = rtalloc(sizeof(GDALDataType) * info->nband_count);
-	if (info->gdalbandtype == NULL) {
+	if (info->gdalbandtype == NULL)
+	{
 		rterror(_("convert_raster: Could not allocate memory for storing GDAL data type"));
 		GDALClose(hdsSrc);
 		return 0;
 	}
 	info->bandtype = rtalloc(sizeof(rt_pixtype) * info->nband_count);
-	if (info->bandtype == NULL) {
+	if (info->bandtype == NULL)
+	{
 		rterror(_("convert_raster: Could not allocate memory for storing pixel type"));
 		GDALClose(hdsSrc);
 		return 0;
 	}
 	info->hasnodata = rtalloc(sizeof(int) * info->nband_count);
-	if (info->hasnodata == NULL) {
+	if (info->hasnodata == NULL)
+	{
 		rterror(_("convert_raster: Could not allocate memory for storing hasnodata flag"));
 		GDALClose(hdsSrc);
 		return 0;
 	}
 	info->nodataval = rtalloc(sizeof(double) * info->nband_count);
-	if (info->nodataval == NULL) {
+	if (info->nodataval == NULL)
+	{
 		rterror(_("convert_raster: Could not allocate memory for storing nodata value"));
 		GDALClose(hdsSrc);
 		return 0;
@@ -1706,15 +1817,19 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 	tilesize = 0;
 
 	/* go through bands for attributes */
-	for (i = 0; i < info->nband_count; i++) {
+	for (i = 0; i < info->nband_count; i++)
+	{
 		hbandSrc = GDALGetRasterBand(hdsSrc, info->nband[i]);
 
 		/* datatype */
 		info->gdalbandtype[i] = GDALGetRasterDataType(hbandSrc);
 
 		/* complex data type? */
-		if (GDALDataTypeIsComplex(info->gdalbandtype[i])) {
-			rterror(_("convert_raster: The pixel type of band %d is a complex data type.  PostGIS raster does not support complex data types"), i + 1);
+		if (GDALDataTypeIsComplex(info->gdalbandtype[i]))
+		{
+			rterror(
+			    _("convert_raster: The pixel type of band %d is a complex data type.  PostGIS raster does not support complex data types"),
+			    i + 1);
 			GDALClose(hdsSrc);
 			return 0;
 		}
@@ -1725,9 +1840,11 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 		/* hasnodata and nodataval */
 		info->nodataval[i] = GDALGetRasterNoDataValue(hbandSrc, &(info->hasnodata[i]));
-		if (!info->hasnodata[i]) {
+		if (!info->hasnodata[i])
+		{
 			/* does NOT have nodata value, but user-specified */
-			if (config->hasnodata) {
+			if (config->hasnodata)
+			{
 				info->hasnodata[i] = 1;
 				info->nodataval[i] = config->nodataval;
 			}
@@ -1775,18 +1892,21 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 		rtwarn(_("The size of each output tile may exceed 1 GB. Use -t to specify a reasonable tile size"));
 
 	/* out-db raster */
-	if (config->outdb) {
+	if (config->outdb)
+	{
 		GDALClose(hdsSrc);
 
 		/* each tile is a raster */
-		for (ytile = 0; ytile < ntiles[1]; ytile++) {
+		for (ytile = 0; ytile < ntiles[1]; ytile++)
+		{
 			/* edge y tile */
 			if (!config->pad_tile && ntiles[1] > 1 && (ytile + 1) == ntiles[1])
 				_tile_size[1] = info->dim[1] - (ytile * info->tile_size[1]);
 			else
 				_tile_size[1] = info->tile_size[1];
 
-			for (xtile = 0; xtile < ntiles[0]; xtile++) {
+			for (xtile = 0; xtile < ntiles[0]; xtile++)
+			{
 				int tile_is_nodata = !config->skip_nodataval_check;
 
 				/* edge x tile */
@@ -1796,15 +1916,16 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 					_tile_size[0] = info->tile_size[0];
 
 				/* compute tile's upper-left corner */
-				GDALApplyGeoTransform(
-					info->gt,
-					xtile * info->tile_size[0], ytile * info->tile_size[1],
-					&(gt[0]), &(gt[3])
-				);
+				GDALApplyGeoTransform(info->gt,
+						      xtile * info->tile_size[0],
+						      ytile * info->tile_size[1],
+						      &(gt[0]),
+						      &(gt[3]));
 
 				/* create raster object */
 				rast = rt_raster_new(_tile_size[0], _tile_size[1]);
-				if (rast == NULL) {
+				if (rast == NULL)
+				{
 					rterror(_("convert_raster: Could not create raster"));
 					return 0;
 				}
@@ -1814,22 +1935,25 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 				rt_raster_set_geotransform_matrix(rast, gt);
 
 				/* add bands */
-				for (i = 0; i < info->nband_count; i++) {
-					band = rt_band_new_offline(
-						_tile_size[0], _tile_size[1],
-						info->bandtype[i],
-						info->hasnodata[i], info->nodataval[i],
-						info->nband[i] - 1,
-						config->rt_file[idx]
-					);
-					if (band == NULL) {
+				for (i = 0; i < info->nband_count; i++)
+				{
+					band = rt_band_new_offline(_tile_size[0],
+								   _tile_size[1],
+								   info->bandtype[i],
+								   info->hasnodata[i],
+								   info->nodataval[i],
+								   info->nband[i] - 1,
+								   config->rt_file[idx]);
+					if (band == NULL)
+					{
 						rterror(_("convert_raster: Could not create offline band"));
 						raster_destroy(rast);
 						return 0;
 					}
 
 					/* add band to raster */
-					if (rt_raster_add_band(rast, band, rt_raster_get_num_bands(rast)) == -1) {
+					if (rt_raster_add_band(rast, band, rt_raster_get_num_bands(rast)) == -1)
+					{
 						rterror(_("convert_raster: Could not add offlineband to raster"));
 						rt_band_destroy(band);
 						raster_destroy(rast);
@@ -1857,14 +1981,20 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 					append_stringbuffer(tileset, hex);
 
 				/* flush if tileset gets too big */
-				if (tileset->length >= config->max_tiles_per_copy ) {
-					if (!insert_records(
-						config->schema, config->table, config->raster_column,
-						(config->file_column ? config->rt_filename[idx] : NULL), config->file_column_name,
-						config->copy_statements, config->out_srid,
-						tileset, buffer
-					)) {
-						rterror(_("convert_raster: Could not convert raster tiles into INSERT or COPY statements"));
+				if (tileset->length >= config->max_tiles_per_copy)
+				{
+					if (!insert_records(config->schema,
+							    config->table,
+							    config->raster_column,
+							    (config->file_column ? config->rt_filename[idx] : NULL),
+							    config->file_column_name,
+							    config->copy_statements,
+							    config->out_srid,
+							    tileset,
+							    buffer))
+					{
+						rterror(_(
+						    "convert_raster: Could not convert raster tiles into INSERT or COPY statements"));
 						return 0;
 					}
 
@@ -1874,12 +2004,14 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 		}
 	}
 	/* in-db raster */
-	else {
+	else
+	{
 		VRTDatasetH hdsDst;
 		VRTSourcedRasterBandH hbandDst;
 
 		/* each tile is a VRT with constraints set for just the data required for the tile */
-		for (ytile = 0; ytile < ntiles[1]; ytile++) {
+		for (ytile = 0; ytile < ntiles[1]; ytile++)
+		{
 
 			/* edge y tile */
 			if (!config->pad_tile && ntiles[1] > 1 && (ytile + 1) == ntiles[1])
@@ -1887,7 +2019,8 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 			else
 				_tile_size[1] = info->tile_size[1];
 
-			for (xtile = 0; xtile < ntiles[0]; xtile++) {
+			for (xtile = 0; xtile < ntiles[0]; xtile++)
+			{
 				int tile_is_nodata = !config->skip_nodataval_check;
 				/*
 				char fn[100];
@@ -1901,11 +2034,11 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 					_tile_size[0] = info->tile_size[0];
 
 				/* compute tile's upper-left corner */
-				GDALApplyGeoTransform(
-					info->gt,
-					xtile * info->tile_size[0], ytile * info->tile_size[1],
-					&(gt[0]), &(gt[3])
-				);
+				GDALApplyGeoTransform(info->gt,
+						      xtile * info->tile_size[0],
+						      ytile * info->tile_size[1],
+						      &(gt[0]),
+						      &(gt[3]));
 				/*
 				rtinfo(_("tile (%d, %d) gt = (%f, %f, %f, %f, %f, %f)"),
 					xtile, ytile,
@@ -1916,27 +2049,32 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 				/* create VRT dataset */
 				hdsDst = VRTCreate(_tile_size[0], _tile_size[1]);
 				/*
-  	 		GDALSetDescription(hdsDst, fn);
+			GDALSetDescription(hdsDst, fn);
 				*/
 				GDALSetProjection(hdsDst, info->srs);
 				GDALSetGeoTransform(hdsDst, gt);
 
 				/* add bands as simple sources */
-				for (i = 0; i < info->nband_count; i++) {
+				for (i = 0; i < info->nband_count; i++)
+				{
 					GDALAddBand(hdsDst, info->gdalbandtype[i], NULL);
-					hbandDst = (VRTSourcedRasterBandH) GDALGetRasterBand(hdsDst, i + 1);
+					hbandDst = (VRTSourcedRasterBandH)GDALGetRasterBand(hdsDst, i + 1);
 
 					if (info->hasnodata[i])
 						GDALSetRasterNoDataValue(hbandDst, info->nodataval[i]);
 
-					VRTAddSimpleSource(
-						hbandDst, GDALGetRasterBand(hdsSrc, info->nband[i]),
-						xtile * info->tile_size[0], ytile * info->tile_size[1],
-						_tile_size[0], _tile_size[1],
-						0, 0,
-						_tile_size[0], _tile_size[1],
-						"near", VRT_NODATA_UNSET
-					);
+					VRTAddSimpleSource(hbandDst,
+							   GDALGetRasterBand(hdsSrc, info->nband[i]),
+							   xtile * info->tile_size[0],
+							   ytile * info->tile_size[1],
+							   _tile_size[0],
+							   _tile_size[1],
+							   0,
+							   0,
+							   _tile_size[0],
+							   _tile_size[1],
+							   "near",
+							   VRT_NODATA_UNSET);
 				}
 
 				/* make sure VRT reflects all changes */
@@ -1944,7 +2082,8 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 				/* convert VRT dataset to rt_raster */
 				rast = rt_raster_from_gdal_dataset(hdsDst);
-				if (rast == NULL) {
+				if (rast == NULL)
+				{
 					rterror(_("convert_raster: Could not convert VRT dataset to PostGIS raster"));
 					GDALClose(hdsDst);
 					return 0;
@@ -1955,7 +2094,8 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 
 				/* inspect each band of raster where band is NODATA */
 				numbands = rt_raster_get_num_bands(rast);
-				for (i = 0; i < numbands; i++) {
+				for (i = 0; i < numbands; i++)
+				{
 					band = rt_raster_get_band(rast, i);
 					if (band != NULL && !config->skip_nodataval_check)
 						tile_is_nodata = tile_is_nodata && rt_band_check_is_nodata(band);
@@ -1980,14 +2120,20 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 				GDALClose(hdsDst);
 
 				/* flush if tileset gets too big */
-				if (tileset->length >= config->max_tiles_per_copy ) {
-					if (!insert_records(
-						config->schema, config->table, config->raster_column,
-						(config->file_column ? config->rt_filename[idx] : NULL), config->file_column_name,
-						config->copy_statements, config->out_srid,
-						tileset, buffer
-					)) {
-						rterror(_("convert_raster: Could not convert raster tiles into INSERT or COPY statements"));
+				if (tileset->length >= config->max_tiles_per_copy)
+				{
+					if (!insert_records(config->schema,
+							    config->table,
+							    config->raster_column,
+							    (config->file_column ? config->rt_filename[idx] : NULL),
+							    config->file_column_name,
+							    config->copy_statements,
+							    config->out_srid,
+							    tileset,
+							    buffer))
+					{
+						rterror(_(
+						    "convert_raster: Could not convert raster tiles into INSERT or COPY statements"));
 						GDALClose(hdsSrc);
 						return 0;
 					}
@@ -2004,31 +2150,40 @@ convert_raster(int idx, RTLOADERCFG *config, RASTERINFO *info, STRINGBUFFER *til
 }
 
 static int
-process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
+process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer)
+{
 	uint32_t i = 0;
 
 	assert(config != NULL);
 	assert(config->table != NULL);
 	assert(config->raster_column != NULL);
 
-	if (config->transaction) {
-		if (!append_sql_to_buffer(buffer, strdup("BEGIN;"))) {
+	if (config->transaction)
+	{
+		if (!append_sql_to_buffer(buffer, strdup("BEGIN;")))
+		{
 			rterror(_("process_rasters: Could not add BEGIN statement to string buffer"));
 			return 0;
 		}
 	}
 
 	/* drop table */
-	if (config->opt == 'd') {
-		if (!drop_table(config->schema, config->table, buffer)) {
+	if (config->opt == 'd')
+	{
+		if (!drop_table(config->schema, config->table, buffer))
+		{
 			rterror(_("process_rasters: Could not add DROP TABLE statement to string buffer"));
 			return 0;
 		}
 
-		if (config->overview_count) {
-			for (i = 0; i < config->overview_count; i++) {
-				if (!drop_table(config->schema, config->overview_table[i], buffer)) {
-					rterror(_("process_rasters: Could not add an overview's DROP TABLE statement to string buffer"));
+		if (config->overview_count)
+		{
+			for (i = 0; i < config->overview_count; i++)
+			{
+				if (!drop_table(config->schema, config->overview_table[i], buffer))
+				{
+					rterror(_(
+					    "process_rasters: Could not add an overview's DROP TABLE statement to string buffer"));
 					return 0;
 				}
 			}
@@ -2036,26 +2191,36 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 	}
 
 	/* create table */
-	if (config->opt != 'a') {
-		if (!create_table(
-			config->schema, config->table, config->raster_column,
-			config->file_column, config->file_column_name,
-			config->tablespace, config->idx_tablespace,
-			buffer
-		)) {
+	if (config->opt != 'a')
+	{
+		if (!create_table(config->schema,
+				  config->table,
+				  config->raster_column,
+				  config->file_column,
+				  config->file_column_name,
+				  config->tablespace,
+				  config->idx_tablespace,
+				  buffer))
+		{
 			rterror(_("process_rasters: Could not add CREATE TABLE statement to string buffer"));
 			return 0;
 		}
 
-		if (config->overview_count) {
-			for (i = 0; i < config->overview_count; i++) {
-				if (!create_table(
-					config->schema, config->overview_table[i], config->raster_column,
-					config->file_column, config->file_column_name,
-					config->tablespace, config->idx_tablespace,
-					buffer
-				)) {
-					rterror(_("process_rasters: Could not add an overview's CREATE TABLE statement to string buffer"));
+		if (config->overview_count)
+		{
+			for (i = 0; i < config->overview_count; i++)
+			{
+				if (!create_table(config->schema,
+						  config->overview_table[i],
+						  config->raster_column,
+						  config->file_column,
+						  config->file_column_name,
+						  config->tablespace,
+						  config->idx_tablespace,
+						  buffer))
+				{
+					rterror(_(
+					    "process_rasters: Could not add an overview's CREATE TABLE statement to string buffer"));
 					return 0;
 				}
 			}
@@ -2063,12 +2228,14 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 	}
 
 	/* no need to run if opt is 'p' */
-	if (config->opt != 'p') {
+	if (config->opt != 'p')
+	{
 		RASTERINFO refinfo;
 		init_rastinfo(&refinfo);
 
 		/* process each raster */
-		for (i = 0; i < config->rt_file_count; i++) {
+		for (i = 0; i < config->rt_file_count; i++)
+		{
 			RASTERINFO rastinfo;
 			STRINGBUFFER tileset;
 
@@ -2078,7 +2245,8 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 			init_stringbuffer(&tileset);
 
 			/* convert raster */
-			if (!convert_raster(i, config, &rastinfo, &tileset, buffer)) {
+			if (!convert_raster(i, config, &rastinfo, &tileset, buffer))
+			{
 				rterror(_("process_rasters: Could not process raster: %s"), config->rt_file[i]);
 				rtdealloc_rastinfo(&rastinfo);
 				rtdealloc_stringbuffer(&tileset, 0);
@@ -2086,14 +2254,18 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 			}
 
 			/* process raster tiles into COPY or INSERT statements */
-			if (tileset.length && !insert_records(
-				config->schema, config->table, config->raster_column,
-				(config->file_column ? config->rt_filename[i] : NULL),
-        config->file_column_name,
-				config->copy_statements, config->out_srid,
-				&tileset, buffer
-			)) {
-				rterror(_("process_rasters: Could not convert raster tiles into INSERT or COPY statements"));
+			if (tileset.length && !insert_records(config->schema,
+							      config->table,
+							      config->raster_column,
+							      (config->file_column ? config->rt_filename[i] : NULL),
+							      config->file_column_name,
+							      config->copy_statements,
+							      config->out_srid,
+							      &tileset,
+							      buffer))
+			{
+				rterror(_(
+				    "process_rasters: Could not convert raster tiles into INSERT or COPY statements"));
 				rtdealloc_rastinfo(&rastinfo);
 				rtdealloc_stringbuffer(&tileset, 0);
 				return 0;
@@ -2105,25 +2277,37 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 			flush_stringbuffer(buffer);
 
 			/* overviews */
-			if (config->overview_count) {
+			if (config->overview_count)
+			{
 				uint32_t j = 0;
 
-				for (j = 0; j < config->overview_count; j++) {
+				for (j = 0; j < config->overview_count; j++)
+				{
 
-					if (!build_overview(i, config, &rastinfo, j, &tileset, buffer)) {
-						rterror(_("process_rasters: Could not create overview of factor %d for raster %s"), config->overview[j], config->rt_file[i]);
+					if (!build_overview(i, config, &rastinfo, j, &tileset, buffer))
+					{
+						rterror(
+						    _("process_rasters: Could not create overview of factor %d for raster %s"),
+						    config->overview[j],
+						    config->rt_file[i]);
 						rtdealloc_rastinfo(&rastinfo);
 						rtdealloc_stringbuffer(&tileset, 0);
 						return 0;
 					}
 
-					if (tileset.length && !insert_records(
-						config->schema, config->overview_table[j], config->raster_column,
-						(config->file_column ? config->rt_filename[i] : NULL), config->file_column_name,
-						config->copy_statements, config->out_srid,
-						&tileset, buffer
-					)) {
-						rterror(_("process_rasters: Could not convert overview tiles into INSERT or COPY statements"));
+					if (tileset.length &&
+					    !insert_records(config->schema,
+							    config->overview_table[j],
+							    config->raster_column,
+							    (config->file_column ? config->rt_filename[i] : NULL),
+							    config->file_column_name,
+							    config->copy_statements,
+							    config->out_srid,
+							    &tileset,
+							    buffer))
+					{
+						rterror(_(
+						    "process_rasters: Could not convert overview tiles into INSERT or COPY statements"));
 						rtdealloc_rastinfo(&rastinfo);
 						rtdealloc_stringbuffer(&tileset, 0);
 						return 0;
@@ -2136,10 +2320,12 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 				}
 			}
 
-			if (config->rt_file_count > 1) {
+			if (config->rt_file_count > 1)
+			{
 				if (i < 1)
 					copy_rastinfo(&refinfo, &rastinfo);
-				else {
+				else
+				{
 					diff_rastinfo(&rastinfo, &refinfo);
 				}
 			}
@@ -2151,47 +2337,48 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 	}
 
 	/* index */
-	if (config->idx) {
+	if (config->idx)
+	{
 		/* create index */
-		if (!create_index(
-			config->schema, config->table, config->raster_column,
-			config->idx_tablespace,
-			buffer
-		)) {
+		if (!create_index(config->schema, config->table, config->raster_column, config->idx_tablespace, buffer))
+		{
 			rterror(_("process_rasters: Could not add CREATE INDEX statement to string buffer"));
 			return 0;
 		}
 
 		/* analyze */
-		if (config->opt != 'p') {
-			if (!analyze_table(
-				config->schema, config->table,
-				buffer
-			)) {
+		if (config->opt != 'p')
+		{
+			if (!analyze_table(config->schema, config->table, buffer))
+			{
 				rterror(_("process_rasters: Could not add ANALYZE statement to string buffer"));
 				return 0;
 			}
 		}
 
-		if (config->overview_count) {
-			for (i = 0; i < config->overview_count; i++) {
+		if (config->overview_count)
+		{
+			for (i = 0; i < config->overview_count; i++)
+			{
 				/* create index */
-				if (!create_index(
-					config->schema, config->overview_table[i], config->raster_column,
-					config->idx_tablespace,
-					buffer
-				)) {
-					rterror(_("process_rasters: Could not add an overview's CREATE INDEX statement to string buffer"));
+				if (!create_index(config->schema,
+						  config->overview_table[i],
+						  config->raster_column,
+						  config->idx_tablespace,
+						  buffer))
+				{
+					rterror(_(
+					    "process_rasters: Could not add an overview's CREATE INDEX statement to string buffer"));
 					return 0;
 				}
 
 				/* analyze */
-				if (config->opt != 'p') {
-					if (!analyze_table(
-						config->schema, config->overview_table[i],
-						buffer
-					)) {
-						rterror(_("process_rasters: Could not add an overview's ANALYZE statement to string buffer"));
+				if (config->opt != 'p')
+				{
+					if (!analyze_table(config->schema, config->overview_table[i], buffer))
+					{
+						rterror(_(
+						    "process_rasters: Could not add an overview's ANALYZE statement to string buffer"));
 						return 0;
 					}
 				}
@@ -2200,24 +2387,32 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 	}
 
 	/* add constraints */
-	if (config->constraints) {
-		if (!add_raster_constraints(
-			config->schema, config->table, config->raster_column,
-			config->regular_blocking, config->max_extent,
-			buffer
-		)) {
+	if (config->constraints)
+	{
+		if (!add_raster_constraints(config->schema,
+					    config->table,
+					    config->raster_column,
+					    config->regular_blocking,
+					    config->max_extent,
+					    buffer))
+		{
 			rterror(_("process:rasters: Could not add AddRasterConstraints statement to string buffer"));
 			return 0;
 		}
 
-		if (config->overview_count) {
-			for (i = 0; i < config->overview_count; i++) {
-				if (!add_raster_constraints(
-					config->schema, config->overview_table[i], config->raster_column,
-					config->regular_blocking, config->max_extent,
-					buffer
-				)) {
-					rterror(_("process_rasters: Could not add an overview's AddRasterConstraints statement to string buffer"));
+		if (config->overview_count)
+		{
+			for (i = 0; i < config->overview_count; i++)
+			{
+				if (!add_raster_constraints(config->schema,
+							    config->overview_table[i],
+							    config->raster_column,
+							    config->regular_blocking,
+							    config->max_extent,
+							    buffer))
+				{
+					rterror(_(
+					    "process_rasters: Could not add an overview's AddRasterConstraints statement to string buffer"));
 					return 0;
 				}
 			}
@@ -2225,56 +2420,64 @@ process_rasters(RTLOADERCFG *config, STRINGBUFFER *buffer) {
 	}
 
 	/* overview constraint is automatically added */
-	if (config->overview_count) {
-		for (i = 0; i < config->overview_count; i++) {
-			if (!add_overview_constraints(
-				config->schema, config->overview_table[i], config->raster_column,
-				config->schema, config->table, config->raster_column,
-				config->overview[i],
-				buffer
-			)) {
-				rterror(_("process_rasters: Could not add an overview's AddOverviewConstraints statement to string buffer"));
+	if (config->overview_count)
+	{
+		for (i = 0; i < config->overview_count; i++)
+		{
+			if (!add_overview_constraints(config->schema,
+						      config->overview_table[i],
+						      config->raster_column,
+						      config->schema,
+						      config->table,
+						      config->raster_column,
+						      config->overview[i],
+						      buffer))
+			{
+				rterror(_(
+				    "process_rasters: Could not add an overview's AddOverviewConstraints statement to string buffer"));
 				return 0;
 			}
 		}
 	}
 
-	if (config->transaction) {
-		if (!append_sql_to_buffer(buffer, strdup("END;"))) {
+	if (config->transaction)
+	{
+		if (!append_sql_to_buffer(buffer, strdup("END;")))
+		{
 			rterror(_("process_rasters: Could not add END statement to string buffer"));
 			return 0;
 		}
 	}
 
 	/* maintenance */
-	if (config->opt != 'p' && config->maintenance) {
-		if (!vacuum_table(
-			config->schema, config->table,
-			buffer
-		)) {
+	if (config->opt != 'p' && config->maintenance)
+	{
+		if (!vacuum_table(config->schema, config->table, buffer))
+		{
 			rterror(_("process_rasters: Could not add VACUUM statement to string buffer"));
 			return 0;
 		}
 
-		if (config->overview_count) {
-			for (i = 0; i < config->overview_count; i++) {
-				if (!vacuum_table(
-					config->schema, config->overview_table[i],
-					buffer
-				)) {
-					rterror(_("process_rasters: Could not add an overview's VACUUM statement to string buffer"));
+		if (config->overview_count)
+		{
+			for (i = 0; i < config->overview_count; i++)
+			{
+				if (!vacuum_table(config->schema, config->overview_table[i], buffer))
+				{
+					rterror(_(
+					    "process_rasters: Could not add an overview's VACUUM statement to string buffer"));
 					return 0;
 				}
 			}
 		}
-
 	}
 
 	return 1;
 }
 
 int
-main(int argc, char **argv) {
+main(int argc, char **argv)
+{
 	RTLOADERCFG *config = NULL;
 	STRINGBUFFER *buffer = NULL;
 	uint32_t i = 0;
@@ -2288,55 +2491,65 @@ main(int argc, char **argv) {
 	rt_init_allocators();
 
 #ifdef USE_NLS
-	setlocale (LC_ALL, "");
-	bindtextdomain (PACKAGE, LOCALEDIR);
-	textdomain (PACKAGE);
+	setlocale(LC_ALL, "");
+	bindtextdomain(PACKAGE, LOCALEDIR);
+	textdomain(PACKAGE);
 #endif
 
 	/* no args, show usage */
-	if (argc == 1) {
+	if (argc == 1)
+	{
 		usage();
 		exit(0);
 	}
 
 	/* initialize config */
 	config = rtalloc(sizeof(RTLOADERCFG));
-	if (config == NULL) {
+	if (config == NULL)
+	{
 		rterror(_("Could not allocate memory for loader configuration"));
 		exit(1);
 	}
 	init_config(config);
 
 	/****************************************************************************
-	* parse arguments
-	****************************************************************************/
+	 * parse arguments
+	 ****************************************************************************/
 
-	for (argit = 1; argit < argc; argit++) {
+	for (argit = 1; argit < argc; argit++)
+	{
 		char *optarg, *ptr;
 		/* srid */
 
-		if (CSEQUAL(argv[argit], "-s") && argit < argc - 1) {
+		if (CSEQUAL(argv[argit], "-s") && argit < argc - 1)
+		{
 			optarg = argv[++argit];
 			ptr = strchr(optarg, ':');
-			if (ptr) {
+			if (ptr)
+			{
 				*ptr++ = '\0';
 				sscanf(optarg, "%d", &config->srid);
 				sscanf(ptr, "%d", &config->out_srid);
-			} else {
+			}
+			else
+			{
 				config->srid = atoi(optarg);
 			}
 		}
 		/* band index */
-		else if (CSEQUAL(argv[argit], "-b") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-b") && argit < argc - 1)
+		{
 			elements = strsplit(argv[++argit], ",", &n);
-			if (n < 1) {
+			if (n < 1)
+			{
 				rterror(_("Could not process -b"));
 				rtdealloc_config(config);
 				exit(1);
 			}
 
 			config->nband_count = 0;
-			for (j = 0; j < n; j++) {
+			for (j = 0; j < n; j++)
+			{
 				char *t = trim(elements[j]);
 				char **minmax = NULL;
 				int *range = NULL;
@@ -2347,8 +2560,10 @@ main(int argc, char **argv) {
 
 				/* is t a range? */
 				minmax = strsplit(t, "-", &o);
-				if (o == 2) {
-					if (!array_range(atoi(minmax[0]), atoi(minmax[1]), 1, &range, &p)) {
+				if (o == 2)
+				{
+					if (!array_range(atoi(minmax[0]), atoi(minmax[1]), 1, &range, &p))
+					{
 						rterror(_("Could not allocate memory for storing band indices"));
 						for (l = 0; l < o; l++)
 							rtdealloc(minmax[l]);
@@ -2361,10 +2576,12 @@ main(int argc, char **argv) {
 						exit(1);
 					}
 				}
-				else {
+				else
+				{
 					p = 1;
 					range = rtalloc(sizeof(int));
-					if (range == NULL) {
+					if (range == NULL)
+					{
 						rterror(_("Could not allocate memory for storing band indices"));
 						for (l = 0; l < o; l++)
 							rtdealloc(minmax[l]);
@@ -2382,7 +2599,8 @@ main(int argc, char **argv) {
 				m = config->nband_count;
 				config->nband_count += p;
 				config->nband = rtrealloc(config->nband, sizeof(int) * config->nband_count);
-				if (config->nband == NULL) {
+				if (config->nband == NULL)
+				{
 					rterror(_("Could not allocate memory for storing band indices"));
 					rtdealloc(range);
 					for (l = 0; l < o; l++)
@@ -2412,8 +2630,10 @@ main(int argc, char **argv) {
 			elements = NULL;
 			n = 0;
 
-			for (j = 0; j < config->nband_count; j++) {
-				if (config->nband[j] < 1) {
+			for (j = 0; j < config->nband_count; j++)
+			{
+				if (config->nband[j] < 1)
+				{
 					rterror(_("Band index %d must be greater than 0"), config->nband[j]);
 					rtdealloc_config(config);
 					exit(1);
@@ -2421,20 +2641,25 @@ main(int argc, char **argv) {
 			}
 		}
 		/* tile size */
-		else if (CSEQUAL(argv[argit], "-t") && argit < argc - 1) {
-			if (CSEQUAL(argv[++argit], "auto")) {
+		else if (CSEQUAL(argv[argit], "-t") && argit < argc - 1)
+		{
+			if (CSEQUAL(argv[++argit], "auto"))
+			{
 				config->tile_size[0] = -1;
 				config->tile_size[1] = -1;
 			}
-			else {
+			else
+			{
 				elements = strsplit(argv[argit], "x", &n);
-				if (n != 2) {
+				if (n != 2)
+				{
 					rterror(_("Could not process -t"));
 					rtdealloc_config(config);
 					exit(1);
 				}
 
-				for (j = 0; j < n; j++) {
+				for (j = 0; j < n; j++)
+				{
 					char *t = trim(elements[j]);
 					config->tile_size[j] = atoi(t);
 					rtdealloc(t);
@@ -2444,8 +2669,10 @@ main(int argc, char **argv) {
 				elements = NULL;
 				n = 0;
 
-				for (j = 0; j < 2; j++) {
-					if (config->tile_size[j] < 1) {
+				for (j = 0; j < 2; j++)
+				{
+					if (config->tile_size[j] < 1)
+					{
 						rterror(_("Tile size must be greater than 0x0"));
 						rtdealloc_config(config);
 						exit(1);
@@ -2454,34 +2681,42 @@ main(int argc, char **argv) {
 			}
 		}
 		/* pad tiles */
-		else if (CSEQUAL(argv[argit], "-P")) {
+		else if (CSEQUAL(argv[argit], "-P"))
+		{
 			config->pad_tile = 1;
 		}
 		/* out-of-db raster */
-		else if (CSEQUAL(argv[argit], "-R")) {
+		else if (CSEQUAL(argv[argit], "-R"))
+		{
 			config->outdb = 1;
 		}
 		/* drop table and recreate */
-		else if (CSEQUAL(argv[argit], "-d")) {
+		else if (CSEQUAL(argv[argit], "-d"))
+		{
 			config->opt = 'd';
 		}
 		/* append to table */
-		else if (CSEQUAL(argv[argit], "-a")) {
+		else if (CSEQUAL(argv[argit], "-a"))
+		{
 			config->opt = 'a';
 		}
 		/* create new table */
-		else if (CSEQUAL(argv[argit], "-c")) {
+		else if (CSEQUAL(argv[argit], "-c"))
+		{
 			config->opt = 'c';
 		}
 		/* prepare only */
-		else if (CSEQUAL(argv[argit], "-p")) {
+		else if (CSEQUAL(argv[argit], "-p"))
+		{
 			config->opt = 'p';
 		}
 		/* raster column name */
-		else if (CSEQUAL(argv[argit], "-f") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-f") && argit < argc - 1)
+		{
 			const size_t len = (strlen(argv[++argit]) + 1);
 			config->raster_column = rtalloc(sizeof(char) * len);
-			if (config->raster_column == NULL) {
+			if (config->raster_column == NULL)
+			{
 				rterror(_("Could not allocate memory for storing raster column name"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2489,14 +2724,17 @@ main(int argc, char **argv) {
 			strncpy(config->raster_column, argv[argit], len);
 		}
 		/* filename column */
-		else if (CSEQUAL(argv[argit], "-F")) {
+		else if (CSEQUAL(argv[argit], "-F"))
+		{
 			config->file_column = 1;
 		}
 		/* filename column name */
-		else if (CSEQUAL(argv[argit], "-n") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-n") && argit < argc - 1)
+		{
 			const size_t len = (strlen(argv[++argit]) + 1);
 			config->file_column_name = rtalloc(sizeof(char) * len);
-			if (config->file_column_name == NULL) {
+			if (config->file_column_name == NULL)
+			{
 				rterror(_("Could not allocate memory for storing filename column name"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2505,9 +2743,11 @@ main(int argc, char **argv) {
 			config->file_column = 1;
 		}
 		/* overview factors */
-		else if (CSEQUAL(argv[argit], "-l") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-l") && argit < argc - 1)
+		{
 			elements = strsplit(argv[++argit], ",", &n);
-			if (n < 1) {
+			if (n < 1)
+			{
 				rterror(_("Could not process -l"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2515,12 +2755,14 @@ main(int argc, char **argv) {
 
 			config->overview_count = n;
 			config->overview = rtalloc(sizeof(int) * n);
-			if (config->overview == NULL) {
+			if (config->overview == NULL)
+			{
 				rterror(_("Could not allocate memory for storing overview factors"));
 				rtdealloc_config(config);
 				exit(1);
 			}
-			for (j = 0; j < n; j++) {
+			for (j = 0; j < n; j++)
+			{
 				char *t = trim(elements[j]);
 				config->overview[j] = atoi(t);
 				rtdealloc(t);
@@ -2530,43 +2772,56 @@ main(int argc, char **argv) {
 			elements = NULL;
 			n = 0;
 
-			for (j = 0; j < (uint32_t)config->overview_count; j++) {
-				if (config->overview[j] < MINOVFACTOR || config->overview[j] > MAXOVFACTOR) {
-					rterror(_("Overview factor %d is not between %d and %d"), config->overview[j], MINOVFACTOR, MAXOVFACTOR);
+			for (j = 0; j < (uint32_t)config->overview_count; j++)
+			{
+				if (config->overview[j] < MINOVFACTOR || config->overview[j] > MAXOVFACTOR)
+				{
+					rterror(_("Overview factor %d is not between %d and %d"),
+						config->overview[j],
+						MINOVFACTOR,
+						MAXOVFACTOR);
 					rtdealloc_config(config);
 					exit(1);
 				}
 			}
 		}
 		/* quote identifiers */
-		else if (CSEQUAL(argv[argit], "-q")) {
+		else if (CSEQUAL(argv[argit], "-q"))
+		{
 			config->quoteident = 1;
 		}
 		/* create index */
-		else if (CSEQUAL(argv[argit], "-I")) {
+		else if (CSEQUAL(argv[argit], "-I"))
+		{
 			config->idx = 1;
 		}
 		/* maintenance */
-		else if (CSEQUAL(argv[argit], "-M")) {
+		else if (CSEQUAL(argv[argit], "-M"))
+		{
 			config->maintenance = 1;
 		}
 		/* set constraints */
-		else if (CSEQUAL(argv[argit], "-C")) {
+		else if (CSEQUAL(argv[argit], "-C"))
+		{
 			config->constraints = 1;
 		}
 		/* disable extent constraint */
-		else if (CSEQUAL(argv[argit], "-x")) {
+		else if (CSEQUAL(argv[argit], "-x"))
+		{
 			config->max_extent = 0;
 		}
 		/* enable regular_blocking */
-		else if (CSEQUAL(argv[argit], "-r")) {
+		else if (CSEQUAL(argv[argit], "-r"))
+		{
 			config->regular_blocking = 1;
 		}
 		/* tablespace of new table */
-		else if (CSEQUAL(argv[argit], "-T") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-T") && argit < argc - 1)
+		{
 			const size_t len = (strlen(argv[++argit]) + 1);
 			config->tablespace = rtalloc(len);
-			if (config->tablespace == NULL) {
+			if (config->tablespace == NULL)
+			{
 				rterror(_("Could not allocate memory for storing tablespace of new table"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2574,10 +2829,12 @@ main(int argc, char **argv) {
 			strncpy(config->tablespace, argv[argit], len);
 		}
 		/* tablespace of new index */
-		else if (CSEQUAL(argv[argit], "-X") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-X") && argit < argc - 1)
+		{
 			const size_t len = (strlen(argv[++argit]) + 1);
 			config->idx_tablespace = rtalloc(len);
-			if (config->idx_tablespace == NULL) {
+			if (config->idx_tablespace == NULL)
+			{
 				rterror(_("Could not allocate memory for storing tablespace of new indices"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2585,52 +2842,63 @@ main(int argc, char **argv) {
 			strncpy(config->idx_tablespace, argv[argit], len);
 		}
 		/* nodata value */
-		else if (CSEQUAL(argv[argit], "-N") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-N") && argit < argc - 1)
+		{
 			config->hasnodata = 1;
 			config->nodataval = atof(argv[++argit]);
 		}
 		/* skip NODATA value check for bands */
-		else if (CSEQUAL(argv[argit], "-k")) {
+		else if (CSEQUAL(argv[argit], "-k"))
+		{
 			config->skip_nodataval_check = 1;
 		}
 		/* endianness */
-		else if (CSEQUAL(argv[argit], "-E") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-E") && argit < argc - 1)
+		{
 			config->endian = atoi(argv[++argit]);
 			config->endian = 1;
 		}
 		/* version */
-		else if (CSEQUAL(argv[argit], "-V") && argit < argc - 1) {
+		else if (CSEQUAL(argv[argit], "-V") && argit < argc - 1)
+		{
 			config->version = atoi(argv[++argit]);
 			config->version = 0;
 		}
 		/* transaction */
-		else if (CSEQUAL(argv[argit], "-e")) {
+		else if (CSEQUAL(argv[argit], "-e"))
+		{
 			config->transaction = 0;
 		}
 		/* COPY statements */
-		else if (CSEQUAL(argv[argit], "-Y")) {
+		else if (CSEQUAL(argv[argit], "-Y"))
+		{
 			config->copy_statements = 1;
 			/* max tiles per copy */
-			if ( argit < argc - 1) {
+			if (argit < argc - 1)
+			{
 				optarg = argv[argit + 1];
-				if (atoi(optarg) > 0 ) {
+				if (atoi(optarg) > 0)
+				{
 					config->max_tiles_per_copy = atoi(optarg);
 					++argit;
 				}
 			}
 		}
 
-
 		/* GDAL formats */
-		else if (CSEQUAL(argv[argit], "-G")) {
+		else if (CSEQUAL(argv[argit], "-G"))
+		{
 			uint32_t drv_count = 0;
 			rt_gdaldriver drv_set = rt_raster_gdal_drivers(&drv_count, 0);
-			if (drv_set == NULL || !drv_count) {
+			if (drv_set == NULL || !drv_count)
+			{
 				rterror(_("Could not get list of available GDAL raster formats"));
 			}
-			else {
+			else
+			{
 				printf(_("Supported GDAL raster formats:\n"));
-				for (j = 0; j < drv_count; j++) {
+				for (j = 0; j < drv_count; j++)
+				{
 					printf(_("  %s\n"), drv_set[j].long_name);
 
 					rtdealloc(drv_set[j].short_name);
@@ -2644,16 +2912,19 @@ main(int argc, char **argv) {
 			exit(0);
 		}
 		/* help */
-		else if (CSEQUAL(argv[argit], "-?")) {
+		else if (CSEQUAL(argv[argit], "-?"))
+		{
 			usage();
 			rtdealloc_config(config);
 			exit(0);
 		}
-		else {
+		else
+		{
 			size_t len;
 			config->rt_file_count++;
-			config->rt_file = (char **) rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
-			if (config->rt_file == NULL) {
+			config->rt_file = (char **)rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
+			if (config->rt_file == NULL)
+			{
 				rterror(_("Could not allocate memory for storing raster files"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2661,7 +2932,8 @@ main(int argc, char **argv) {
 
 			len = strlen(argv[argit]) + 1;
 			config->rt_file[config->rt_file_count - 1] = rtalloc(sizeof(char) * len);
-			if (config->rt_file[config->rt_file_count - 1] == NULL) {
+			if (config->rt_file[config->rt_file_count - 1] == NULL)
+			{
 				rterror(_("Could not allocate memory for storing raster filename"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2670,8 +2942,10 @@ main(int argc, char **argv) {
 		}
 	}
 
-	if (config->srid != config->out_srid && config->out_srid != SRID_UNKNOWN) {
-		if (config->copy_statements) {
+	if (config->srid != config->out_srid && config->out_srid != SRID_UNKNOWN)
+	{
+		if (config->copy_statements)
+		{
 			rterror(_("Invalid argument combination - cannot use -Y with -s FROM_SRID:TO_SRID"));
 			exit(1);
 		}
@@ -2681,7 +2955,8 @@ main(int argc, char **argv) {
 	GDALAllRegister();
 
 	/* no files provided */
-	if (!config->rt_file_count) {
+	if (!config->rt_file_count)
+	{
 		rterror(_("No raster provided"));
 		rtdealloc_config(config);
 		exit(1);
@@ -2690,38 +2965,55 @@ main(int argc, char **argv) {
 		at least two files, see if last is table
 		last isn't recognized by GDAL
 	*/
-	else if (config->rt_file_count > 1) {
+	else if (config->rt_file_count > 1)
+	{
 		drv = GDALIdentifyDriver(config->rt_file[config->rt_file_count - 1], NULL);
 
-		if (drv == NULL) {
+		if (drv == NULL)
+		{
 			char *ptr;
 			ptr = strchr(config->rt_file[config->rt_file_count - 1], '.');
 
 			/* schema.table */
-			if (ptr) {
-				config->schema = rtalloc(sizeof(char) * (ptr - config->rt_file[config->rt_file_count - 1] + 1));
-				if (config->schema == NULL) {
+			if (ptr)
+			{
+				config->schema =
+				    rtalloc(sizeof(char) * (ptr - config->rt_file[config->rt_file_count - 1] + 1));
+				if (config->schema == NULL)
+				{
 					rterror(_("Could not allocate memory for storing schema name"));
 					rtdealloc_config(config);
 					exit(1);
 				}
-				snprintf(config->schema, ptr - config->rt_file[config->rt_file_count - 1] + 1, "%s", config->rt_file[config->rt_file_count - 1]);
+				snprintf(config->schema,
+					 ptr - config->rt_file[config->rt_file_count - 1] + 1,
+					 "%s",
+					 config->rt_file[config->rt_file_count - 1]);
 				config->schema[ptr - config->rt_file[config->rt_file_count - 1]] = '\0';
 
-				config->table = rtalloc(sizeof(char) * (strlen(config->rt_file[config->rt_file_count - 1]) - strlen(config->schema) + 1));
-				if (config->table == NULL) {
+				config->table =
+				    rtalloc(sizeof(char) * (strlen(config->rt_file[config->rt_file_count - 1]) -
+							    strlen(config->schema) + 1));
+				if (config->table == NULL)
+				{
 					rterror(_("Could not allocate memory for storing table name"));
 					rtdealloc_config(config);
 					exit(1);
 				}
-				snprintf(config->table, strlen(config->rt_file[config->rt_file_count - 1]) - strlen(config->schema), "%s", ptr + 1);
-				config->table[strlen(config->rt_file[config->rt_file_count - 1]) - strlen(config->schema)] = '\0';
+				snprintf(config->table,
+					 strlen(config->rt_file[config->rt_file_count - 1]) - strlen(config->schema),
+					 "%s",
+					 ptr + 1);
+				config->table[strlen(config->rt_file[config->rt_file_count - 1]) -
+					      strlen(config->schema)] = '\0';
 			}
 			/* table */
-			else {
+			else
+			{
 				const size_t len = strlen(config->rt_file[config->rt_file_count - 1]) + 1;
 				config->table = rtalloc(sizeof(char) * len);
-				if (config->table == NULL) {
+				if (config->table == NULL)
+				{
 					rterror(_("Could not allocate memory for storing table name"));
 					rtdealloc_config(config);
 					exit(1);
@@ -2730,8 +3022,9 @@ main(int argc, char **argv) {
 			}
 
 			rtdealloc(config->rt_file[--(config->rt_file_count)]);
-			config->rt_file = (char **) rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
-			if (config->rt_file == NULL) {
+			config->rt_file = (char **)rtrealloc(config->rt_file, sizeof(char *) * config->rt_file_count);
+			if (config->rt_file == NULL)
+			{
 				rterror(_("Could not reallocate the memory holding raster names"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2740,14 +3033,16 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* validate raster files
-	****************************************************************************/
+	 * validate raster files
+	 ****************************************************************************/
 
 	/* check that GDAL recognizes all files */
-	for (i = 0; i < config->rt_file_count; i++) {
+	for (i = 0; i < config->rt_file_count; i++)
+	{
 		drv = GDALIdentifyDriver(config->rt_file[i], NULL);
 
-		if (drv == NULL) {
+		if (drv == NULL)
+		{
 			rterror(_("Unable to read raster file: %s"), config->rt_file[i]);
 			rtdealloc_config(config);
 			exit(1);
@@ -2755,33 +3050,39 @@ main(int argc, char **argv) {
 	}
 
 	/* process each file for just the filename */
-	config->rt_filename = (char **) rtalloc(sizeof(char *) * config->rt_file_count);
-	if (config->rt_filename == NULL) {
+	config->rt_filename = (char **)rtalloc(sizeof(char *) * config->rt_file_count);
+	if (config->rt_filename == NULL)
+	{
 		rterror(_("Could not allocate memory for cleaned raster filenames"));
 		rtdealloc_config(config);
 		exit(1);
 	}
-	for (i = 0; i < config->rt_file_count; i++) {
+	for (i = 0; i < config->rt_file_count; i++)
+	{
 		char *file;
 		char *ptr;
 
 		file = rtalloc(sizeof(char) * (strlen(config->rt_file[i]) + 1));
-		if (file == NULL) {
+		if (file == NULL)
+		{
 			rterror(_("Could not allocate memory for cleaned raster filename"));
 			rtdealloc_config(config);
 			exit(1);
 		}
 		strcpy(file, config->rt_file[i]);
 
-		for (ptr = file + strlen(file); ptr > file; ptr--) {
-			if (*ptr == '/' || *ptr == '\\') {
+		for (ptr = file + strlen(file); ptr > file; ptr--)
+		{
+			if (*ptr == '/' || *ptr == '\\')
+			{
 				ptr++;
 				break;
 			}
 		}
 
 		config->rt_filename[i] = rtalloc(sizeof(char) * (strlen(ptr) + 1));
-		if (config->rt_filename[i] == NULL) {
+		if (config->rt_filename[i] == NULL)
+		{
 			rterror(_("Could not allocate memory for cleaned raster filename"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2791,31 +3092,36 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* defaults for table and column names
-	****************************************************************************/
+	 * defaults for table and column names
+	 ****************************************************************************/
 
 	/* first file as proxy table name */
-	if (config->table == NULL) {
+	if (config->table == NULL)
+	{
 		char *file;
 		char *ptr;
 
 		file = rtalloc(sizeof(char) * (strlen(config->rt_filename[0]) + 1));
-		if (file == NULL) {
+		if (file == NULL)
+		{
 			rterror(_("Could not allocate memory for proxy table name"));
 			rtdealloc_config(config);
 			exit(1);
 		}
 		strcpy(file, config->rt_filename[0]);
 
-		for (ptr = file + strlen(file); ptr > file; ptr--) {
-			if (*ptr == '.') {
+		for (ptr = file + strlen(file); ptr > file; ptr--)
+		{
+			if (*ptr == '.')
+			{
 				*ptr = '\0';
 				break;
 			}
 		}
 
 		config->table = rtalloc(sizeof(char) * (strlen(file) + 1));
-		if (config->table == NULL) {
+		if (config->table == NULL)
+		{
 			rterror(_("Could not allocate memory for proxy table name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2825,9 +3131,11 @@ main(int argc, char **argv) {
 	}
 
 	/* raster_column not specified, default to "rast" */
-	if (config->raster_column == NULL) {
+	if (config->raster_column == NULL)
+	{
 		config->raster_column = rtalloc(sizeof(char) * (strlen("rast") + 1));
-		if (config->raster_column == NULL) {
+		if (config->raster_column == NULL)
+		{
 			rterror(_("Could not allocate memory for default raster column name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2836,9 +3144,11 @@ main(int argc, char **argv) {
 	}
 
 	/* file_column_name not specified, default to "filename" */
-	if (config->file_column_name == NULL) {
+	if (config->file_column_name == NULL)
+	{
 		config->file_column_name = rtalloc(sizeof(char) * (strlen("filename") + 1));
-		if (config->file_column_name == NULL) {
+		if (config->file_column_name == NULL)
+		{
 			rterror(_("Could not allocate memory for default filename column name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2847,11 +3157,12 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* literal PostgreSQL identifiers disabled
-	****************************************************************************/
+	 * literal PostgreSQL identifiers disabled
+	 ****************************************************************************/
 
 	/* no quotes, lower case everything */
-	if (!config->quoteident) {
+	if (!config->quoteident)
+	{
 		if (config->schema != NULL)
 			config->schema = strtolower(config->schema);
 		if (config->table != NULL)
@@ -2867,23 +3178,28 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* overview table names
-	****************************************************************************/
+	 * overview table names
+	 ****************************************************************************/
 
-	if (config->overview_count) {
+	if (config->overview_count)
+	{
 		char factor[4];
 		config->overview_table = rtalloc(sizeof(char *) * config->overview_count);
-		if (config->overview_table == NULL) {
+		if (config->overview_table == NULL)
+		{
 			rterror(_("Could not allocate memory for overview table names"));
 			rtdealloc_config(config);
 			exit(1);
 		}
 
-		for (i = 0; i < config->overview_count; i++) {
+		for (i = 0; i < config->overview_count; i++)
+		{
 			sprintf(factor, "%d", config->overview[i]);
 
-			config->overview_table[i] = rtalloc(sizeof(char) * (strlen("o__") + strlen(factor) + strlen(config->table) + 1));
-			if (config->overview_table[i] == NULL) {
+			config->overview_table[i] =
+			    rtalloc(sizeof(char) * (strlen("o__") + strlen(factor) + strlen(config->table) + 1));
+			if (config->overview_table[i] == NULL)
+			{
 				rterror(_("Could not allocate memory for overview table name"));
 				rtdealloc_config(config);
 				exit(1);
@@ -2893,63 +3209,74 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* check that identifiers won't get truncated
-	****************************************************************************/
+	 * check that identifiers won't get truncated
+	 ****************************************************************************/
 
-	if (config->schema != NULL && strlen(config->schema) > MAXNAMELEN) {
-		rtwarn(_("The schema name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->schema,
-			MAXNAMELEN
-		);
+	if (config->schema != NULL && strlen(config->schema) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The schema name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->schema,
+		    MAXNAMELEN);
 	}
-	if (config->table != NULL && strlen(config->table) > MAXNAMELEN) {
-		rtwarn(_("The table name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->table,
-			MAXNAMELEN
-		);
+	if (config->table != NULL && strlen(config->table) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The table name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->table,
+		    MAXNAMELEN);
 	}
-	if (config->raster_column != NULL && strlen(config->raster_column) > MAXNAMELEN) {
-		rtwarn(_("The column name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->raster_column,
-			MAXNAMELEN
-		);
+	if (config->raster_column != NULL && strlen(config->raster_column) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The column name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->raster_column,
+		    MAXNAMELEN);
 	}
-	if (config->file_column_name != NULL && strlen(config->file_column_name) > MAXNAMELEN) {
-		rtwarn(_("The column name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->file_column_name,
-			MAXNAMELEN
-		);
+	if (config->file_column_name != NULL && strlen(config->file_column_name) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The column name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->file_column_name,
+		    MAXNAMELEN);
 	}
-	if (config->tablespace != NULL && strlen(config->tablespace) > MAXNAMELEN) {
-		rtwarn(_("The tablespace name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->tablespace,
-			MAXNAMELEN
-		);
+	if (config->tablespace != NULL && strlen(config->tablespace) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The tablespace name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->tablespace,
+		    MAXNAMELEN);
 	}
-	if (config->idx_tablespace != NULL && strlen(config->idx_tablespace) > MAXNAMELEN) {
-		rtwarn(_("The index tablespace name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-			config->idx_tablespace,
-			MAXNAMELEN
-		);
+	if (config->idx_tablespace != NULL && strlen(config->idx_tablespace) > MAXNAMELEN)
+	{
+		rtwarn(
+		    _("The index tablespace name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+		    config->idx_tablespace,
+		    MAXNAMELEN);
 	}
-	if (config->overview_count) {
-		for (i = 0; i < config->overview_count; i++) {
-			if (strlen(config->overview_table[i]) > MAXNAMELEN) {
-				rtwarn(_("The overview table name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
-					config->overview_table[i],
-					MAXNAMELEN
-				);
+	if (config->overview_count)
+	{
+		for (i = 0; i < config->overview_count; i++)
+		{
+			if (strlen(config->overview_table[i]) > MAXNAMELEN)
+			{
+				rtwarn(
+				    _("The overview table name \"%s\" may exceed the maximum string length permitted for PostgreSQL identifiers (%d)"),
+				    config->overview_table[i],
+				    MAXNAMELEN);
 			}
 		}
 	}
 
 	/****************************************************************************
-	* double quote identifiers
-	****************************************************************************/
+	 * double quote identifiers
+	 ****************************************************************************/
 
-	if (config->schema != NULL) {
+	if (config->schema != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->schema) + 4));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting schema name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2959,9 +3286,11 @@ main(int argc, char **argv) {
 		rtdealloc(config->schema);
 		config->schema = tmp;
 	}
-	if (config->table != NULL) {
+	if (config->table != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->table) + 3));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting table name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2971,9 +3300,11 @@ main(int argc, char **argv) {
 		rtdealloc(config->table);
 		config->table = tmp;
 	}
-	if (config->raster_column != NULL) {
+	if (config->raster_column != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->raster_column) + 3));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting raster column name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2983,9 +3314,11 @@ main(int argc, char **argv) {
 		rtdealloc(config->raster_column);
 		config->raster_column = tmp;
 	}
-	if (config->file_column_name != NULL) {
+	if (config->file_column_name != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->file_column_name) + 3));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting raster column name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -2995,9 +3328,11 @@ main(int argc, char **argv) {
 		rtdealloc(config->file_column_name);
 		config->file_column_name = tmp;
 	}
-	if (config->tablespace != NULL) {
+	if (config->tablespace != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->tablespace) + 3));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting tablespace name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -3007,9 +3342,11 @@ main(int argc, char **argv) {
 		rtdealloc(config->tablespace);
 		config->tablespace = tmp;
 	}
-	if (config->idx_tablespace != NULL) {
+	if (config->idx_tablespace != NULL)
+	{
 		tmp = rtalloc(sizeof(char) * (strlen(config->idx_tablespace) + 3));
-		if (tmp == NULL) {
+		if (tmp == NULL)
+		{
 			rterror(_("Could not allocate memory for quoting index tablespace name"));
 			rtdealloc_config(config);
 			exit(1);
@@ -3019,10 +3356,13 @@ main(int argc, char **argv) {
 		rtdealloc(config->idx_tablespace);
 		config->idx_tablespace = tmp;
 	}
-	if (config->overview_count) {
-		for (i = 0; i < config->overview_count; i++) {
+	if (config->overview_count)
+	{
+		for (i = 0; i < config->overview_count; i++)
+		{
 			tmp = rtalloc(sizeof(char) * (strlen(config->overview_table[i]) + 3));
-			if (tmp == NULL) {
+			if (tmp == NULL)
+			{
 				rterror(_("Could not allocate memory for quoting overview table name"));
 				rtdealloc_config(config);
 				exit(1);
@@ -3035,12 +3375,13 @@ main(int argc, char **argv) {
 	}
 
 	/****************************************************************************
-	* processing of rasters
-	****************************************************************************/
+	 * processing of rasters
+	 ****************************************************************************/
 
 	/* initialize string buffer */
 	buffer = rtalloc(sizeof(STRINGBUFFER));
-	if (buffer == NULL) {
+	if (buffer == NULL)
+	{
 		rterror(_("Could not allocate memory for output string buffer"));
 		rtdealloc_config(config);
 		exit(1);
@@ -3048,7 +3389,8 @@ main(int argc, char **argv) {
 	init_stringbuffer(buffer);
 
 	/* pass off to processing function */
-	if (!process_rasters(config, buffer)) {
+	if (!process_rasters(config, buffer))
+	{
 		rterror(_("Unable to process rasters"));
 		rtdealloc_stringbuffer(buffer, 1);
 		rtdealloc_config(config);

--- a/raster/rt_pg/rtpg_internal.c
+++ b/raster/rt_pg/rtpg_internal.c
@@ -27,7 +27,7 @@
  *
  */
 
-#include <ctype.h> /* for isspace */
+#include <ctype.h>    /* for isspace */
 #include <postgres.h> /* for palloc */
 #include <executor/spi.h>
 
@@ -44,19 +44,16 @@
       oldstr : Substring we are looking for
       newstr : Substring we want to replace with
       count  : Optional pointer to int (input / output value). NULL to ignore.
-               Input:  Maximum replacements to be done. NULL or < 1 to do all.
-               Output: Number of replacements done or -1 if not enough memory.
+	       Input:  Maximum replacements to be done. NULL or < 1 to do all.
+	       Output: Number of replacements done or -1 if not enough memory.
   Returns    : Pointer to the new string or NULL if error.
   Notes      :
      - Case sensitive - Otherwise, replace functions "strstr" by "strcasestr"
      - Always allocates memory for the result.
 --------------------------------------------------------------------------- */
-char*
-rtpg_strreplace(
-	const char *str,
-	const char *oldstr, const char *newstr,
-	int *count
-) {
+char *
+rtpg_strreplace(const char *str, const char *oldstr, const char *newstr, int *count)
+{
 	const char *tmp = str;
 	char *result;
 	int found = 0;
@@ -70,19 +67,22 @@ rtpg_strreplace(
 		found++, tmp += oldlen;
 
 	length = strlen(str) + found * (newlen - oldlen);
-	if ((result = (char *) palloc(length + 1)) == NULL) {
+	if ((result = (char *)palloc(length + 1)) == NULL)
+	{
 		fprintf(stderr, "Not enough memory\n");
 		found = -1;
 	}
-	else {
+	else
+	{
 		tmp = str;
 		limit = found; /* Countdown */
-		reslen = 0; /* length of current result */
+		reslen = 0;    /* length of current result */
 
 		/* Replace each old string found with new string  */
-		while ((limit-- > 0) && (tmp = strstr(tmp, oldstr)) != NULL) {
-			length = (tmp - str); /* Number of chars to keep intouched */
-			strncpy(result + reslen, str, length); /* Original part keeped */
+		while ((limit-- > 0) && (tmp = strstr(tmp, oldstr)) != NULL)
+		{
+			length = (tmp - str);                        /* Number of chars to keep intouched */
+			strncpy(result + reslen, str, length);       /* Original part keeped */
 			strcpy(result + (reslen += length), newstr); /* Insert new string */
 
 			reslen += newlen;
@@ -92,12 +92,14 @@ rtpg_strreplace(
 		strcpy(result + reslen, str); /* Copies last part and ending null char */
 	}
 
-	if (count != NULL) *count = found;
+	if (count != NULL)
+		*count = found;
 	return result;
 }
 
 char *
-rtpg_strtoupper(char * str) {
+rtpg_strtoupper(char *str)
+{
 	int j;
 
 	for (j = strlen(str) - 1; j >= 0; j--)
@@ -106,8 +108,9 @@ rtpg_strtoupper(char * str) {
 	return str;
 }
 
-char*
-rtpg_chartrim(const char *input, char *remove) {
+char *
+rtpg_chartrim(const char *input, char *remove)
+{
 	char *rtn = NULL;
 	char *ptr = NULL;
 	uint32_t offset = 0;
@@ -115,19 +118,20 @@ rtpg_chartrim(const char *input, char *remove) {
 	if (!input)
 		return NULL;
 	else if (!*input)
-		return (char *) input;
+		return (char *)input;
 
 	/* trim left */
 	while (strchr(remove, *input) != NULL)
 		input++;
 
 	/* trim right */
-	ptr = ((char *) input) + strlen(input);
+	ptr = ((char *)input) + strlen(input);
 	while (strchr(remove, *--ptr) != NULL)
 		offset++;
 
 	rtn = palloc(sizeof(char) * (strlen(input) - offset + 1));
-	if (!rtn) {
+	if (!rtn)
+	{
 		fprintf(stderr, "Not enough memory\n");
 		return NULL;
 	}
@@ -138,8 +142,9 @@ rtpg_chartrim(const char *input, char *remove) {
 }
 
 /* split a string based on a delimiter */
-char**
-rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n) {
+char **
+rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n)
+{
 	char *tmp = NULL;
 	char **rtn = NULL;
 	char *token = NULL;
@@ -150,21 +155,25 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n) {
 
 	/* copy str to tmp as strtok will mangle the string */
 	tmp = palloc(sizeof(char) * (strlen(str) + 1));
-	if (NULL == tmp) {
+	if (NULL == tmp)
+	{
 		fprintf(stderr, "Not enough memory\n");
 		return NULL;
 	}
 	strcpy(tmp, str);
 
-	if (!strlen(tmp) || !delimiter || !strlen(delimiter)) {
+	if (!strlen(tmp) || !delimiter || !strlen(delimiter))
+	{
 		*n = 1;
-		rtn = (char **) palloc(*n * sizeof(char *));
-		if (NULL == rtn) {
+		rtn = (char **)palloc(*n * sizeof(char *));
+		if (NULL == rtn)
+		{
 			fprintf(stderr, "Not enough memory\n");
 			return NULL;
 		}
-		rtn[0] = (char *) palloc(sizeof(char) * (strlen(tmp) + 1));
-		if (NULL == rtn[0]) {
+		rtn[0] = (char *)palloc(sizeof(char) * (strlen(tmp) + 1));
+		if (NULL == rtn[0])
+		{
 			fprintf(stderr, "Not enough memory\n");
 			return NULL;
 		}
@@ -174,21 +183,26 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n) {
 	}
 
 	token = strtok(tmp, delimiter);
-	while (token != NULL) {
-		if (*n < 1) {
-			rtn = (char **) palloc(sizeof(char *));
+	while (token != NULL)
+	{
+		if (*n < 1)
+		{
+			rtn = (char **)palloc(sizeof(char *));
 		}
-		else {
-			rtn = (char **) repalloc(rtn, (*n + 1) * sizeof(char *));
+		else
+		{
+			rtn = (char **)repalloc(rtn, (*n + 1) * sizeof(char *));
 		}
-		if (NULL == rtn) {
+		if (NULL == rtn)
+		{
 			fprintf(stderr, "Not enough memory\n");
 			return NULL;
 		}
 
 		rtn[*n] = NULL;
-		rtn[*n] = (char *) palloc(sizeof(char) * (strlen(token) + 1));
-		if (NULL == rtn[*n]) {
+		rtn[*n] = (char *)palloc(sizeof(char) * (strlen(token) + 1));
+		if (NULL == rtn[*n])
+		{
 			fprintf(stderr, "Not enough memory\n");
 			return NULL;
 		}
@@ -204,7 +218,8 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n) {
 }
 
 char *
-rtpg_removespaces(char *str) {
+rtpg_removespaces(char *str)
+{
 	char *rtn;
 	char *tmp;
 
@@ -222,8 +237,9 @@ rtpg_removespaces(char *str) {
 	return rtn;
 }
 
-char*
-rtpg_trim(const char *input) {
+char *
+rtpg_trim(const char *input)
+{
 	char *rtn;
 	char *ptr;
 	uint32_t offset = 0;
@@ -232,7 +248,7 @@ rtpg_trim(const char *input) {
 	if (!input)
 		return NULL;
 	else if (!*input)
-		return (char *) input;
+		return (char *)input;
 
 	/* trim left */
 	while (isspace(*input) && *input != '\0')
@@ -240,14 +256,16 @@ rtpg_trim(const char *input) {
 
 	/* trim right */
 	inputlen = strlen(input);
-	if (inputlen) {
-		ptr = ((char *) input) + inputlen;
+	if (inputlen)
+	{
+		ptr = ((char *)input) + inputlen;
 		while (isspace(*--ptr))
 			offset++;
 	}
 
 	rtn = palloc(sizeof(char) * (inputlen - offset + 1));
-	if (rtn == NULL) {
+	if (rtn == NULL)
+	{
 		fprintf(stderr, "Not enough memory\n");
 		return NULL;
 	}
@@ -262,7 +280,8 @@ rtpg_trim(const char *input) {
  * http://stackoverflow.com/a/1634398
  */
 char *
-rtpg_strrstr(const char *s1, const char *s2) {
+rtpg_strrstr(const char *s1, const char *s2)
+{
 	int s1len = strlen(s1);
 	int s2len = strlen(s2);
 	char *s;
@@ -270,7 +289,7 @@ rtpg_strrstr(const char *s1, const char *s2) {
 	if (s2len > s1len)
 		return NULL;
 
-	s = (char *) (s1 + s1len - s2len);
+	s = (char *)(s1 + s1len - s2len);
 	for (; s >= s1; --s)
 		if (strncmp(s, s2, s2len) == 0)
 			return s;
@@ -291,43 +310,48 @@ rtpg_getSR(int32_t srid)
 	char *tmp = NULL;
 	char *srs = NULL;
 
-/*
-SELECT
-	CASE
-		WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND length(COALESCE(auth_srid::text, '')) > 0
-			THEN upper(auth_name) || ':' || auth_srid
-		WHEN length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0
-			THEN COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')
-		ELSE ''
-	END,
-	proj4text,
-	srtext
-FROM spatial_ref_sys
-WHERE srid = X
-LIMIT 1
-*/
+	/*
+	SELECT
+		CASE
+			WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND
+	length(COALESCE(auth_srid::text, '')) > 0 THEN upper(auth_name) || ':' || auth_srid WHEN
+	length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0 THEN COALESCE(auth_name, '') ||
+	COALESCE(auth_srid::text, '') ELSE '' END, proj4text, srtext FROM spatial_ref_sys WHERE srid = X LIMIT 1
+	*/
 
-	len = sizeof(char) * (strlen("SELECT CASE WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND length(COALESCE(auth_srid::text, '')) > 0 THEN upper(auth_name) || ':' || auth_srid WHEN length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0 THEN COALESCE(auth_name, '') || COALESCE(auth_srid::text, '') ELSE '' END, proj4text, srtext FROM spatial_ref_sys WHERE srid =  LIMIT 1") + MAX_INT_CHARLEN + 1);
-	sql = (char *) palloc(len);
-	if (NULL == sql) {
+	len =
+	    sizeof(char) *
+	    (strlen(
+		 "SELECT CASE WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND length(COALESCE(auth_srid::text, '')) > 0 THEN upper(auth_name) || ':' || auth_srid WHEN length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0 THEN COALESCE(auth_name, '') || COALESCE(auth_srid::text, '') ELSE '' END, proj4text, srtext FROM spatial_ref_sys WHERE srid =  LIMIT 1") +
+	     MAX_INT_CHARLEN + 1);
+	sql = (char *)palloc(len);
+	if (NULL == sql)
+	{
 		elog(ERROR, "rtpg_getSR: Could not allocate memory for sql\n");
 		return NULL;
 	}
 
 	spi_result = SPI_connect();
-	if (spi_result != SPI_OK_CONNECT) {
+	if (spi_result != SPI_OK_CONNECT)
+	{
 		pfree(sql);
 		elog(ERROR, "rtpg_getSR: Could not connect to database using SPI\n");
 		return NULL;
 	}
 
 	/* execute query */
-	snprintf(sql, len, "SELECT CASE WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND length(COALESCE(auth_srid::text, '')) > 0 THEN upper(auth_name) || ':' || auth_srid WHEN length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0 THEN COALESCE(auth_name, '') || COALESCE(auth_srid::text, '') ELSE '' END, proj4text, srtext FROM spatial_ref_sys WHERE srid = %d LIMIT 1", srid);
+	snprintf(
+	    sql,
+	    len,
+	    "SELECT CASE WHEN (upper(auth_name) = 'EPSG' OR upper(auth_name) = 'EPSGA') AND length(COALESCE(auth_srid::text, '')) > 0 THEN upper(auth_name) || ':' || auth_srid WHEN length(COALESCE(auth_name, '') || COALESCE(auth_srid::text, '')) > 0 THEN COALESCE(auth_name, '') || COALESCE(auth_srid::text, '') ELSE '' END, proj4text, srtext FROM spatial_ref_sys WHERE srid = %d LIMIT 1",
+	    srid);
 	POSTGIS_RT_DEBUGF(4, "SRS query: %s", sql);
 	spi_result = SPI_execute(sql, TRUE, 0);
 	SPI_pfree(sql);
-	if (spi_result != SPI_OK_SELECT || SPI_tuptable == NULL || SPI_processed != 1) {
-		if (SPI_tuptable) SPI_freetuptable(tuptable);
+	if (spi_result != SPI_OK_SELECT || SPI_tuptable == NULL || SPI_processed != 1)
+	{
+		if (SPI_tuptable)
+			SPI_freetuptable(tuptable);
 		SPI_finish();
 		elog(ERROR, "rtpg_getSR: Cannot find SRID (%d) in spatial_ref_sys", srid);
 		return NULL;
@@ -338,24 +362,23 @@ LIMIT 1
 	tuple = tuptable->vals[0];
 
 	/* which column to use? */
-	for (i = 1; i < 4; i++) {
+	for (i = 1; i < 4; i++)
+	{
 		tmp = SPI_getvalue(tuple, tupdesc, i);
 
 		/* value AND GDAL supports this SR */
-		if (
-			SPI_result != SPI_ERROR_NOATTRIBUTE &&
-			SPI_result != SPI_ERROR_NOOUTFUNC &&
-			tmp != NULL &&
-			strlen(tmp) &&
-			rt_util_gdal_supported_sr(tmp)
-		) {
+		if (SPI_result != SPI_ERROR_NOATTRIBUTE && SPI_result != SPI_ERROR_NOOUTFUNC && tmp != NULL &&
+		    strlen(tmp) && rt_util_gdal_supported_sr(tmp))
+		{
 			POSTGIS_RT_DEBUGF(4, "Value for column %d is %s", i, tmp);
 
 			len = strlen(tmp) + 1;
 			srs = SPI_palloc(sizeof(char) * len);
-			if (NULL == srs) {
+			if (NULL == srs)
+			{
 				pfree(tmp);
-				if (SPI_tuptable) SPI_freetuptable(tuptable);
+				if (SPI_tuptable)
+					SPI_freetuptable(tuptable);
 				SPI_finish();
 				elog(ERROR, "rtpg_getSR: Could not allocate memory for spatial reference text\n");
 				return NULL;
@@ -371,12 +394,15 @@ LIMIT 1
 		continue;
 	}
 
-	if (SPI_tuptable) SPI_freetuptable(tuptable);
+	if (SPI_tuptable)
+		SPI_freetuptable(tuptable);
 	SPI_finish();
 
 	/* unable to get SR info */
-	if (srs == NULL) {
-		if (SPI_tuptable) SPI_freetuptable(tuptable);
+	if (srs == NULL)
+	{
+		if (SPI_tuptable)
+			SPI_freetuptable(tuptable);
 		SPI_finish();
 		elog(ERROR, "rtpg_getSR: Could not find a viable spatial reference for SRID (%d)", srid);
 		return NULL;

--- a/raster/rt_pg/rtpg_internal.c
+++ b/raster/rt_pg/rtpg_internal.c
@@ -148,6 +148,7 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n)
 	char *tmp = NULL;
 	char **rtn = NULL;
 	char *token = NULL;
+	char *saveptr = NULL;
 
 	*n = 0;
 	if (!str)
@@ -182,7 +183,7 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n)
 		return rtn;
 	}
 
-	token = strtok(tmp, delimiter);
+	token = strtok_r(tmp, delimiter, &saveptr);
 	while (token != NULL)
 	{
 		if (*n < 1)
@@ -210,7 +211,7 @@ rtpg_strsplit(const char *str, const char *delimiter, uint32_t *n)
 		strcpy(rtn[*n], token);
 		*n = *n + 1;
 
-		token = strtok(NULL, delimiter);
+		token = strtok_r(NULL, delimiter, &saveptr);
 	}
 
 	pfree(tmp);


### PR DESCRIPTION
## Summary

Implements **sonarcloud-cleanup Phase 4** — replace all 8 non-reentrant `strtok()` call sites across 4 files with the thread-safe `strtok_r()`.

**Base**: `fix/sonarcloud-phase3a-memory-safety` (PR #18). When PR #18 merges, GitHub auto-retargets this PR to `develop`.

## Call sites fixed

| File | Function | saveptr scope |
|---|---|---|
| `liblwgeom/optionlist.c` | `option_list_parse()` | local per-function |
| `liblwgeom/optionlist.c` | `option_list_gdal_parse()` | local per-function |
| `postgis/lwgeom_geos.c` | ST_Buffer parameter parser | local per-function |
| `postgis/lwgeom_geos.c` | ST_OffsetCurve parameter parser | local per-function |
| `raster/loader/raster2pgsql.c` | `strsplit()` | local per-function |
| `raster/rt_pg/rtpg_internal.c` | `rtpg_strsplit()` | local per-function |

Each function has a single tokenization session (init + loop), so one `char *saveptr = NULL;` local per function is sufficient. No cross-function state leakage.

## Portability

`strtok_r` is POSIX.1-2001 and available on all targets including MSYS2/mingw. No portability shim required.

## Commit structure

```
d93e301b0  Replace non-reentrant strtok with strtok_r for thread safety  (logic, 15/9)
6e3a4259c  Style-only: reformat rtpg_internal.c to match .clang-format    (style, 192 lines)
0e17290a7  Style-only: reformat raster2pgsql.c to match .clang-format     (style, 1976 lines)
f1259824b  Style-only: reformat lwgeom_geos.c to match .clang-format      (style, 833 lines)
```

**Style-only commits** are necessary because the pre-commit `clang-format --dry-run --Werror` hook checks entire files, and these three files had large accumulated style debt (4,700+ violations combined) that would otherwise block any logic commit touching them. Separating style from logic per CLAUDE.md keeps the `d93e301b0` commit minimal and cherry-pickable for upstream contribution later.

## Category

**UPSTREAM_READY** per the four-way classification in `upstream-postgis-contribution-roadmap`. The `d93e301b0` logic commit is a genuine thread-safety fix upstream `postgis/postgis` would benefit from. The style-only commits are fork-internal and should NOT be included in any upstream PR — they're bundled here only to satisfy the fork's strict pre-commit hook.

## Test plan

- [ ] Full CI matrix passes (ASan, USan, mingw, latest, pg14-18, SonarCloud Scan)
- [ ] Existing optionlist, ST_Buffer, ST_OffsetCurve, raster2pgsql regression tests pass (no behavior change)
- [ ] SonarCloud S5272 (or equivalent strtok rule) count decreases by 8

## References

- Phase 4 tasks: `openspec/changes/sonarcloud-cleanup/tasks.md` (4.1–4.6)
- Agent investigation (2026-04-12): all 8 sites verified as TRIVIAL paired tokenization sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)